### PR TITLE
Remove the restriction of `nbytes` in unsafe_read

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -11,7 +11,7 @@ This function is similar to `Base.unsafe_read` but is different in some points:
 - It returns the number of bytes written to `output`.
 - It does not block if there are buffered data in `input`.
 """
-function unsafe_read(input::IO, output::Ptr{UInt8}, nbytes::Integer)::Int
+function unsafe_read(input::IO, output::Ptr{UInt8}, nbytes::Integer)
     nbytes = convert(UInt, nbytes)
     p = output
     navail = bytesavailable(input)

--- a/src/io.jl
+++ b/src/io.jl
@@ -12,6 +12,7 @@ This function is similar to `Base.unsafe_read` but is different in some points:
 - It does not block if there are buffered data in `input`.
 """
 function unsafe_read(input::IO, output::Ptr{UInt8}, nbytes::Integer)::Int
+    nbytes = convert(UInt, nbytes)
     p = output
     navail = bytesavailable(input)
     if navail == 0 && nbytes > 0 && !eof(input)

--- a/src/io.jl
+++ b/src/io.jl
@@ -11,7 +11,7 @@ This function is similar to `Base.unsafe_read` but is different in some points:
 - It returns the number of bytes written to `output`.
 - It does not block if there are buffered data in `input`.
 """
-function unsafe_read(input::IO, output::Ptr{UInt8}, nbytes::Int)::Int
+function unsafe_read(input::IO, output::Ptr{UInt8}, nbytes::Integer)::Int
     p = output
     navail = bytesavailable(input)
     if navail == 0 && nbytes > 0 && !eof(input)


### PR DESCRIPTION
The original restriction of `Int` will cause errors in some cases. Replaced with `Integer` instead. I think this also aligns with the signatures in Base.