### PR TITLE
seekend should return stream like Base.seekend

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -284,7 +284,7 @@ function Base.seekstart(stream::TranscodingStream)
         emptybuffer!(stream.state.buffer2)
     end
     seekstart(stream.stream)
-    return
+    return stream
 end
 
 function Base.seekend(stream::TranscodingStream)
@@ -296,7 +296,7 @@ function Base.seekend(stream::TranscodingStream)
         emptybuffer!(stream.state.buffer2)
     end
     seekend(stream.stream)
-    return
+    return stream
 end
 
 


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/blob/ae8452a9e0b973991c30f27beb2201db1b0ea0d3/base/iostream.jl#L164

This would make it more of a drop-in replacement for an IOStream.