### PR TITLE
Fix `position` for `NoopStream` in :write mode

### DIFF
--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -283,4 +283,29 @@
     @test_throws ArgumentError NoopStream(let s = IOBuffer(); close(s); s; end)
     @test_throws ArgumentError TranscodingStream(Noop(), IOBuffer(), bufsize=0)
     @test_throws ArgumentError TranscodingStream(Noop(), IOBuffer(), sharedbuf=true)
+
+    @testset "position" begin
+        iob = IOBuffer()
+        sink = IOBuffer()
+        stream = NoopStream(sink, bufsize=16)
+        @test position(stream) == position(iob)
+        for len in 0:10:100
+            write(stream, repeat("x", len))
+            write(iob, repeat("x", len))
+            @test position(stream) == position(iob)
+        end
+        @test position(stream) == position(sink) == position(iob)
+        close(stream)
+        close(iob)
+
+        mktemp() do path, sink
+            stream = NoopStream(sink, bufsize=16)
+            pos = 0
+            for len in 0:10:100
+                write(stream, repeat("x", len))
+                pos += len
+                @test position(stream) == pos
+            end
+        end
+    end
 end

--- a/test/codecquadruple.jl
+++ b/test/codecquadruple.jl
@@ -83,4 +83,28 @@ end
     stream = TranscodingStream(QuadrupleCodec(), IOBuffer("foo"))
     @test_throws EOFError unsafe_read(stream, pointer(Vector{UInt8}(undef, 13)), 13)
     close(stream)
+
+    @testset "position" begin
+        iob = IOBuffer()
+        sink = IOBuffer()
+        stream = TranscodingStream(QuadrupleCodec(), sink, bufsize=16)
+        @test position(stream) == position(iob)
+        for len in 0:10:100
+            write(stream, repeat("x", len))
+            write(iob, repeat("x", len))
+            @test position(stream) == position(iob)
+        end
+        close(stream)
+        close(iob)
+
+        mktemp() do path, sink
+            stream = TranscodingStream(QuadrupleCodec(), sink, bufsize=16)
+            pos = 0
+            for len in 0:10:100
+                write(stream, repeat("x", len))
+                pos += len
+                @test position(stream) == pos
+            end
+        end
+    end
 end


### PR DESCRIPTION
I noticed the following on master:
```julia
julia> using TranscodingStreams

julia> sink = IOBuffer()
IOBuffer(data=UInt8[...], readable=true, writable=true, seekable=true, append=false, size=0, maxsize=Inf, ptr=1, mark=-1)

julia> stream = NoopStream(sink, bufsize=16)
NoopStream{IOBuffer}(<mode=idle>)

julia> write(stream, "aaa")
3

julia> position(stream)
-3
```

With this PR, we get `position(stream) == 3`