### PR TITLE
GC safepoints for read and write

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -360,6 +360,7 @@ function Base.unsafe_read(stream::TranscodingStream, output::Ptr{UInt8}, nbytes:
         m = min(buffersize(buffer), p_end - p)
         copydata!(p, buffer, m)
         p += m
+        GC.safepoint()
     end
     if p < p_end && eof(stream)
         throw(EOFError())
@@ -462,6 +463,7 @@ function Base.unsafe_write(stream::TranscodingStream, input::Ptr{UInt8}, nbytes:
         m = min(marginsize(buffer1), p_end - p)
         copydata!(buffer1, p, m)
         p += m
+        GC.safepoint()
     end
     return Int(p - input)
 end


### PR DESCRIPTION
`unsafe_read()` and `unsafe_write()` could be long running, and while they chunk the work, they don't yield to GC. This can lead to long pauses on concurrent work. Example test script:

```Julia
using TranscodingStreams
using CodecXz

@assert Threads.nthreads() > 1

const compressed_path = joinpath(homedir(), "compressed.bin")
const decompressed_path = joinpath(homedir(), "decompressed.bin")

function run_transcoding(data_size::Integer)
    data = zeros(UInt8, data_size)
    compress_time = @elapsed open(XzCompressorStream, compressed_path, "w") do io
        write(io, data)
    end
    @show compress_time
    compressed_data = read(compressed_path)
    decompress_read_time = @elapsed open(XzDecompressorStream, compressed_path, "r") do io
        read(io)
    end
    @show decompress_read_time
    decompress_write_time = @elapsed open(XzDecompressorStream, decompressed_path, "w") do io
        write(io, compressed_data)
    end
    @show decompress_write_time
end

# Warmup
run_transcoding(100 * 1024^2)

# Long running
task = Threads.@spawn run_transcoding(1000 * 1024^2)

# Concurrent GC
while !istaskdone(task)
    gc_time = @elapsed GC.gc()
    @show gc_time
    sleep(1)
end
```

Ran this with Julia 1.7.3 and `--threads 2`.

Before change:
```
compress_time = 1.292804378
decompress_read_time = 0.33704722
decompress_write_time = 0.431174033
gc_time = 0.241884141
compress_time = 12.710169297
gc_time = 11.685787155
gc_time = 0.604301384
decompress_read_time = 3.11715657
gc_time = 0.575948628
gc_time = 2.361772913
decompress_write_time = 3.319080922
```

After change:
```
compress_time = 1.279681993
decompress_read_time = 0.338312242
decompress_write_time = 0.426014177
gc_time = 0.239875428
gc_time = 0.038381543
gc_time = 0.038343671
gc_time = 0.037472041
gc_time = 0.037609003
gc_time = 0.037599015
gc_time = 0.037561703
gc_time = 0.037734895
gc_time = 0.037729274
gc_time = 0.03757048
gc_time = 0.045178609
gc_time = 0.037559067
gc_time = 0.039300503
compress_time = 13.135037559
gc_time = 0.063863973
gc_time = 0.038249329
gc_time = 0.037609394
decompress_read_time = 3.215280659
gc_time = 0.413119403
gc_time = 0.081934188
gc_time = 0.085435524
decompress_write_time = 3.418526721
```
