### PR TITLE
Grow buffers exponentially, not one byte at a time

### DIFF
--- a/src/noop.jl
+++ b/src/noop.jl
@@ -167,7 +167,7 @@ function fillbuffer(stream::NoopStream; eager::Bool = false)
     end
     nfilled::Int = 0
     while ((!eager && buffersize(buffer) == 0) || (eager && makemargin!(buffer, 0, eager = true) > 0)) && !eof(stream.stream)
-        makemargin!(buffer, 1)
+        makemargin!(buffer, div(length(buffer), 2))
         nfilled += readdata!(stream.stream, buffer)
     end
     buffer.transcoded += nfilled

--- a/src/noop.jl
+++ b/src/noop.jl
@@ -167,7 +167,7 @@ function fillbuffer(stream::NoopStream; eager::Bool = false)
     end
     nfilled::Int = 0
     while ((!eager && buffersize(buffer) == 0) || (eager && makemargin!(buffer, 0, eager = true) > 0)) && !eof(stream.stream)
-        makemargin!(buffer, div(length(buffer), 2))
+        makemargin!(buffer, max(1, div(length(buffer), 2)))
         nfilled += readdata!(stream.stream, buffer)
     end
     buffer.transcoded += nfilled

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -575,7 +575,7 @@ function fillbuffer(stream::TranscodingStream; eager::Bool = false)
             end
             callstartproc(stream, :read)
         end
-        makemargin!(buffer2, 1)
+        makemargin!(buffer2, div(length(buffer2), 2))
         readdata!(stream.stream, buffer2)
         _, Δout = callprocess(stream, buffer2, buffer1)
         nfilled += Δout

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -575,7 +575,7 @@ function fillbuffer(stream::TranscodingStream; eager::Bool = false)
             end
             callstartproc(stream, :read)
         end
-        makemargin!(buffer2, div(length(buffer2), 2))
+        makemargin!(buffer2, max(1, div(length(buffer2), 2)))
         readdata!(stream.stream, buffer2)
         _, Δout = callprocess(stream, buffer2, buffer1)
         nfilled += Δout


### PR DESCRIPTION
To check if a TranscodingStream is eof, it first checks if it has any unused
bytes in its buffer. If not, it will attempt to fill the buffer, and only return
true if no bytes were filled.
If there is no margin in the buffer to fill, it will call `makemargin(buffer, 1)`
to ensure at least 1 byte of space.
In the happy case, this will remove used up bytes.
Unfortunately, buffers do never move data pointed to by their mark. So, when no
space is available due to the entire buffer being filled up with marked data,
the buffer will grow one byte at a time in a loop until the data fills.
This is unacceptable as megabytes of data can theoretically be marked.

This commit changes the growth behaviour to request at least half the buffer's
length in the margin. In most cases, this will do nothing. But in the unhappy
case mentioned above, it will cause the buffer to grow expoentially, until a
proper size is quickly reached.