### PR TITLE
Add splitkwargs methods to avoid excessive allocations

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -135,7 +135,9 @@ end
 
 # Split keyword arguments.
 @nospecialize
+@static if isdefined(Base, :Pairs)
 splitkwargs(kwargs::Base.Pairs, ks::Tuple{Vararg{Symbol}}) = splitkwargs(NamedTuple(kwargs), ks)
+end
 function splitkwargs(kwargs::NamedTuple, ks::Tuple{Vararg{Symbol}})
     non_ks = Base.diff_names(keys(kwargs), ks)
     ks = Base.diff_names(keys(kwargs), non_ks)

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -134,6 +134,13 @@ function Base.show(io::IO, stream::TranscodingStream)
 end
 
 # Split keyword arguments.
+@nospecialize
+splitkwargs(kwargs::Base.Pairs, ks::Tuple{Vararg{Symbol}}) = splitkwargs(NamedTuple(kwargs), ks)
+function splitkwargs(kwargs::NamedTuple, ks::Tuple{Vararg{Symbol}})
+    non_ks = Base.diff_names(keys(kwargs), ks)
+    ks = Base.diff_names(keys(kwargs), non_ks)
+    return NamedTuple{ks}(kwargs), NamedTuple{non_ks}(kwargs)
+end
 function splitkwargs(kwargs, keys)
     hits = []
     others = []
@@ -142,6 +149,7 @@ function splitkwargs(kwargs, keys)
     end
     return hits, others
 end
+@specialize
 
 # Check that mode is valid.
 macro checkmode(validmodes)


### PR DESCRIPTION
On current master, we have the unfortunate situation where users of `splitkwargs` can't avoid some ~8.5K allocations, as shown by:

```julia
julia> @time GzipDecompressorStream(buf)
  0.002668 seconds (8.47 k allocations: 404.656 KiB)
TranscodingStreams.TranscodingStream{GzipDecompressor, Base.BufferStream}(<mode=idle>)
```

With this code in this PR (new method specializations for splitkwargs), as suggested by @nickrobinson251, we now get:

```julia
julia> @time GzipDecompressorStream(buf)
  0.000021 seconds (10 allocations: 32.562 KiB)
TranscodingStreams.TranscodingStream{GzipDecompressor, Base.BufferStream}(<mode=idle>)
```

This was discovered as we're starting to review performanc and allocations in HTTP.jl, which uses `GzipDecompressorStream` to automatically decode responses with the gzip encoding.

Co-Authored-By: Nick Robinson