### PR TITLE
in-place transcode when output size is known

### DIFF
--- a/src/TranscodingStreams.jl
+++ b/src/TranscodingStreams.jl
@@ -7,6 +7,9 @@ export
 
 const ByteData = Union{Vector{UInt8},Base.CodeUnits{UInt8}}
 
+# in-place variant of transcode when output buffer size is known
+function transcode! end
+
 include("memory.jl")
 include("buffer.jl")
 include("error.jl")

--- a/src/transcode.jl
+++ b/src/transcode.jl
@@ -130,7 +130,6 @@ function initial_output_size(codec::Codec, input::Memory)
     )
 end
 # Mutates the provided output buffer. Useful for cases when output size is known. 
-# Removed `makemargin!(output, n)` as it's not necessary
 function transcode!(codec::Codec, data::ByteData,output::Buffer)
     input = Buffer(data)
     error = Error()
@@ -138,7 +137,6 @@ function transcode!(codec::Codec, data::ByteData,output::Buffer)
     if code === :error
         @goto error
     end
-    n = minoutsize(codec, buffermem(input))
     @label process
     Δin, Δout, code = process(codec, buffermem(input), marginmem(output), error)
     @debug(
@@ -158,13 +156,11 @@ function transcode!(codec::Codec, data::ByteData,output::Buffer)
             if startproc(codec, :write, error) === :error
                 @goto error
             end
-            n = minoutsize(codec, buffermem(input))
             @goto process
         end
         resize!(output.data, output.marginpos - 1)
         return output.data
     else
-        n = max(Δout, minoutsize(codec, buffermem(input)))
         @goto process
     end
     @label error


### PR DESCRIPTION
Proposal for https://github.com/JuliaIO/TranscodingStreams.jl/issues/132

This is an initial proposal to tackle in-place decoding by providing the correctly-sized buffer.

It would be hugely beneficial for Arrow format, which is the workhorse of modern data analytics (even Pandas is moving to it as a backend). I've done a quick benchmark and [Arrow.jl is among the slowest parsers](https://github.com/apache/arrow-julia/issues/393), especially with compressed files. Based on profiling, the time spent resizing buffers in `transcode()` is roughly the same as the decoding itself!
Thanks to Arrow IPC file specifications, we always know the output size of a field, however, at the moment we cannot take advantage of it.

This PR defines a new function `transcode!` that would write into a user-provided Buffer.
Benefits are quantified below in the code snippet (eg, 3x faster processing with large texts).
I haven't yet explored the failure modes, I just wanted to start the discussion.

```
using TranscodingStreams, CodecZstd
using BenchmarkTools


text = """
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean sollicitudin
mauris non nisi consectetur, a dapibus urna pretium. Vestibulum non posuere
erat. Donec luctus a turpis eget aliquet. Cras tristique iaculis ex, eu
malesuada sem interdum sed. Vestibulum ante ipsum primis in faucibus orci luctus
et ultrices posuere cubilia Curae; Etiam volutpat, risus nec gravida ultricies,
erat ex bibendum ipsum, sed varius ipsum ipsum vitae dui.
"""

# Array API
decompressor=ZstdDecompressor()
compressed = transcode(ZstdCompressor, text)
@assert sizeof(compressed) < sizeof(text)
@assert transcode(decompressor, compressed) == Vector{UInt8}(text)

# Proposed in-place API, writes directly to output buffer.
output_length = ncodeunits(text)
output=TranscodingStreams.Buffer(output_length)
TranscodingStreams.transcode!(decompressor, compressed, output);
@assert output.data == Vector{UInt8}(text)


# Benchmark on smaller text
compressed = transcode(ZstdCompressor, text)
output=TranscodingStreams.Buffer(ncodeunits(text))
@btime transcode($decompressor, $compressed);
# 2.120 μs (4 allocations: 736 bytes)

@btime(TranscodingStreams.transcode!($decompressor, $compressed, output),evals=1,setup=(output=deepcopy($output)));
# 2.041 μs (2 allocations: 64 bytes)

# Benchmark on longer text
longtext= text^100
compressed = transcode(ZstdCompressor, longtext)
@btime transcode($decompressor, $compressed);
# 10.167 μs (10 allocations: 232.92 KiB)

@btime output=TranscodingStreams.Buffer(ncodeunits($longtext));
# 443.409 ns (3 allocations: 43.47 KiB)
@btime(TranscodingStreams.transcode!($decompressor, $compressed, output),evals=1,setup=(output=deepcopy($output)));
# 3.791 μs (2 allocations: 64 bytes)

```