### PR TITLE
Resolve `transcode` method ambiguity

### DIFF
--- a/src/transcode.jl
+++ b/src/transcode.jl
@@ -40,6 +40,12 @@ function Base.transcode(::Type{C}, args...) where {C<:Codec}
     end
 end
 
+# Disambiguate `Base.transcode(::Type{C}, args...)` above from
+# `Base.transcode(T, ::String)` in Julia `Base`
+function Base.transcode(codec::Type{C}, src::String) where {C<:Codec}
+    return invoke(transcode, Tuple{Any, String}, codec, src)
+end
+
 _default_output_buffer(codec, input) = Buffer(
     initial_output_size(
         codec,

--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -213,6 +213,11 @@
     output = TranscodingStreams.Buffer(Vector{UInt8}())
     @test transcode(Noop(), data, output) === output.data
 
+    data = ""
+    @test String(transcode(Noop, data)) == data
+    data = "foo"
+    @test String(transcode(Noop, data)) == data
+
     TranscodingStreams.test_roundtrip_transcode(Noop, Noop)
     TranscodingStreams.test_roundtrip_read(NoopStream, NoopStream)
     TranscodingStreams.test_roundtrip_write(NoopStream, NoopStream)


### PR DESCRIPTION
The examples in many of the codec packages rely on being able to call `transcode` providing a `Codec` type and a string[^1][^2]. #136 [removed type annotations from the trailing arguments for `transcode(::Type{C}, ...) where {C<:Codec}`](https://github.com/JuliaIO/TranscodingStreams.jl/pull/136/files#diff-070b662fbaa87728d904ec4673449682c5decc1c673b8e5bee249981180de0fbR33) causing a method ambiguity with `transcode(T, src::String)` in Julia `Base`[^3]. This adds an additional method to `Base.transcode` to resolve this ambiguity.

I have added tests for the `Noop` codec to ensure the ambiguity is resolved. I'm wondering whether it makes sense to add a test helper function that downstream packages can use to ensure this functionality remains intact. Let me know if that is something I should add.

Fixes #139.

[^1]: https://github.com/JuliaIO/CodecZlib.jl/tree/f9fddaa28c093c590a7a93358709df2945306bc7#usage
[^2]: https://github.com/JuliaIO/CodecZstd.jl/tree/6327ffa9a3a12fc46d465dcfc8b30bed91cf284b#usage
[^3]: https://github.com/JuliaLang/julia/blob/ff7b8eb00bf887f20bf57fb7e53be0070a242c07/base/c.jl#L306