### PR TITLE
Avoid corrupting data when calling `seekend`

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -200,7 +200,7 @@ function Base.eof(stream::TranscodingStream)
     elseif mode == :read
         return buffersize(stream.state.buffer1) == 0 && fillbuffer(stream) == 0
     elseif mode == :write
-        return true
+        return eof(stream.stream)
     elseif mode == :close
         return true
     elseif mode == :stop
@@ -255,7 +255,7 @@ function Base.skip(stream::TranscodingStream, offset::Integer)
         # TODO: support skip in write mode
         throw(ArgumentError("not in read mode"))
     end
-    return
+    return stream
 end
 
 """
@@ -298,21 +298,14 @@ end
 
 function Base.seekend(stream::TranscodingStream)
     mode = stream.state.mode
-    @checkmode (:idle, :write, :read)
+    buffer1 = stream.state.buffer1
     if mode == :read
-        # Maybe the following commented out
-        # code is what seekend should do in :read mode?
-        # But if so, what should happen in :idle mode?
-        # # skip to end,
-        # # but to get the right position, 
-        # # the rest of the input must be transcoded.
-        # while !eof(stream)
-        #     emptybuffer!(buffer1)
-        # end
-        @warn "seekend while in :read mode is currently buggy"
-    end
-    if mode == :idle
-        changemode!(stream, :write)
+        while !eof(stream)
+            emptybuffer!(buffer1)
+        end
+    else
+        # TODO: support skip in write mode
+        throw(ArgumentError("not in read mode"))
     end
     return stream
 end

--- a/test/codecquadruple.jl
+++ b/test/codecquadruple.jl
@@ -107,4 +107,57 @@ end
             end
         end
     end
+    @testset "seeking write" begin
+        iob = IOBuffer()
+        sink = IOBuffer(collect(b"this will be over written"); write=true)
+        seekstart(sink)
+        stream = TranscodingStream(QuadrupleCodec(), sink, bufsize=16)
+        @test position(stream) == 0
+        # seekend in :idle mode should just change mode to write.
+        # This is to prevent future reads from getting the wrong position.
+        seekend(stream)
+        @test eof(stream)
+        @test position(stream) == 0
+        for len in 0:10:100
+            write(stream, repeat("x", len))
+            # seekend in :write mode should be a noop.
+            # because stream can generally only write at the end.
+            seekend(stream)
+            write(iob, repeat("x", len))
+            seekend(iob)
+            @test position(stream) == position(iob)
+        end
+        # seekstart in :write mode will by default error
+        @test_throws ArgumentError seekstart(stream)
+        @test_throws MethodError seek(stream, 3)
+
+        @test position(stream) == position(iob)
+
+        # close stream but not underlying IO.
+        # This should probably be defined as a public function.
+        TranscodingStreams.changemode!(stream, :close)
+        @test 4*length(take!(iob)) == length(take!(sink))
+
+        close(stream)
+        close(iob)
+    end
+    @testset "seeking read" begin
+        source = IOBuffer(collect(0x01:0xAF); append=true, read=true, write=true)
+        stream = TranscodingStream(QuadrupleCodec(), source, bufsize=16)
+        @test position(stream) == 0
+        # seekstart in :idle mode should seekstart of wrapped IO.
+        seekstart(stream)
+        @test position(stream) == 0
+        @test read(stream, 11) == [1,1,1,1,2,2,2,2,3,3,3,]
+        @test position(stream) == 11
+        # seekstart in :read mode should reset reader and seekstart of wrapped IO.
+        seekstart(stream)
+        @test position(stream) == 0
+        @test read(stream, 11) == [1,1,1,1,2,2,2,2,3,3,3,]
+        @test position(stream) == 11
+        # seekend in :read mode will create a warning
+        @test_logs (:warn,"seekend while in :read mode is currently buggy") seekend(stream)
+        @test_throws MethodError seek(stream, 3)
+        close(stream)
+    end
 end


### PR DESCRIPTION
Fixes #109

I changed the default `seekstart` to error when applied to a stream in `:write` mode, and reset the stream if it is in `:read` mode. It also calls `seekstart` on the wrapped IO.

`seekend(s)` should be equivalent to `skip(s, big number)` in which case it should currently error if the stream is not in `:read` mode.

Also changed `skip` to return the stream to be more consistent.
