### PR TITLE
Set Random and Test to be weak deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,21 +2,23 @@ name = "TranscodingStreams"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.9.13"
+version = "0.10.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[weakdeps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[extensions]
+TestExt = ["Test", "Random"]
+
 [compat]
 julia = "1.6"
 
 [extras]
-CodecBase = "6c391c72-fb7b-5838-ba82-7cfb1bcfecbf"
-CodecXz = "ba30903b-d9e8-5048-a5ec-d1f5b0d4b47b"
-CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
-CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/ext/TestExt.jl
+++ b/ext/TestExt.jl
@@ -1,12 +1,14 @@
-# Test Tools
-# ==========
+module TestExt
 
 using Test: Test
 using Random: seed!, randstring
 
+using TranscodingStreams: TranscodingStreams, initialize, finalize, transcode, 
+    TranscodingStream, NoopStream, buffersize, TOKEN_END
+
 TEST_RANDOM_SEED = 12345
 
-function test_roundtrip_read(encoder, decoder)
+function TranscodingStreams.test_roundtrip_read(encoder, decoder)
     seed!(TEST_RANDOM_SEED)
     for n in vcat(0:30, sort!(rand(500:100_000, 30))), alpha in (0x00:0xff, 0x00:0x0f)
         data = rand(alpha, n)
@@ -17,7 +19,7 @@ function test_roundtrip_read(encoder, decoder)
     end
 end
 
-function test_roundtrip_write(encoder, decoder)
+function TranscodingStreams.test_roundtrip_write(encoder, decoder)
     seed!(TEST_RANDOM_SEED)
     for n in vcat(0:30, sort!(rand(500:100_000, 30))), alpha in (0x00:0xff, 0x00:0x0f)
         data = rand(alpha, n)
@@ -29,7 +31,7 @@ function test_roundtrip_write(encoder, decoder)
     end
 end
 
-function test_roundtrip_transcode(encode, decode)
+function TranscodingStreams.test_roundtrip_transcode(encode, decode)
     seed!(TEST_RANDOM_SEED)
     encoder = encode()
     initialize(encoder)
@@ -44,7 +46,7 @@ function test_roundtrip_transcode(encode, decode)
     finalize(decoder)
 end
 
-function test_roundtrip_lines(encoder, decoder)
+function TranscodingStreams.test_roundtrip_lines(encoder, decoder)
     seed!(TEST_RANDOM_SEED)
     lines = String[]
     buf = IOBuffer()
@@ -60,7 +62,7 @@ function test_roundtrip_lines(encoder, decoder)
     Test.@test hash(lines) == hash(readlines(decoder(buf)))
 end
 
-function test_roundtrip_fileio(Encoder, Decoder)
+function TranscodingStreams.test_roundtrip_fileio(Encoder, Decoder)
     data = b"""
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sit amet tempus felis. Etiam molestie urna placerat iaculis pellentesque. Maecenas porttitor et dolor vitae posuere. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc eget nibh quam. Nullam aliquet interdum fringilla. Duis facilisis, lectus in consectetur varius, lorem sem tempor diam, nec auctor tellus nibh sit amet sapien. In ex nunc, elementum eget facilisis ut, luctus eu orci. Sed sapien urna, accumsan et elit non, auctor pretium massa. Phasellus consectetur nisi suscipit blandit aliquam. Nulla facilisi. Mauris pellentesque sem sit amet mi vestibulum eleifend. Nulla faucibus orci ac lorem efficitur, et blandit orci interdum. Aenean posuere ultrices ex sed rhoncus. Donec malesuada mollis sem, sed varius nunc sodales sed. Curabitur lobortis non justo non tristique.
     """
@@ -74,7 +76,7 @@ function test_roundtrip_fileio(Encoder, Decoder)
     end
 end
 
-function test_chunked_read(Encoder, Decoder)
+function TranscodingStreams.test_chunked_read(Encoder, Decoder)
     seed!(TEST_RANDOM_SEED)
     alpha = b"色即是空"
     encoder = Encoder()
@@ -95,7 +97,7 @@ function test_chunked_read(Encoder, Decoder)
     finalize(encoder)
 end
 
-function test_chunked_write(Encoder, Decoder)
+function TranscodingStreams.test_chunked_write(Encoder, Decoder)
     seed!(TEST_RANDOM_SEED)
     alpha = b"空即是色"
     encoder = Encoder()
@@ -115,3 +117,5 @@ function test_chunked_write(Encoder, Decoder)
     end
     finalize(encoder)
 end
+
+end # module

--- a/src/TranscodingStreams.jl
+++ b/src/TranscodingStreams.jl
@@ -16,6 +16,17 @@ include("stream.jl")
 include("io.jl")
 include("noop.jl")
 include("transcode.jl")
-include("testtools.jl")
+
+function test_roundtrip_read end
+function test_roundtrip_write end
+function test_roundtrip_transcode end
+function test_roundtrip_lines end
+function test_roundtrip_fileio end
+function test_chunked_read end
+function test_chunked_write end
+
+if !isdefined(Base, :get_extension)
+    include("../ext/TestExt.jl")
+end
 
 end # module


### PR DESCRIPTION
The test-related functionality is still there, but requires loading Random and Test.

Note that THIS MIGHT BE A BREAKING CHANGE, since users could call these functions without loading `Test` or `Random` previously.
However, I think we just need to make this breaking change. There is no way around it, and as we begin moving more stuff out of the sysimage, it becomes increasingly annoying that TranscodingStreams has these needless deps.