### PR TITLE
Move downstream tests to GitHub CI

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,0 +1,54 @@
+name: Downstream
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
+    runs-on: ${{ matrix.os }}
+    env:
+      GROUP: ${{ matrix.package.group }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: [1]
+        os: [ubuntu-latest]
+        package:
+          - {user: JuliaIO, repo: CodecZlib.jl, group: TranscodingStreams}
+          - {user: JuliaIO, repo: CodecLz4.jl, group: TranscodingStreams}
+          - {user: JuliaIO, repo: CodecZstd.jl, group: TranscodingStreams}
+          - {user: JuliaIO, repo: CodecBase.jl, group: TranscodingStreams}
+          - {user: JuliaIO, repo: CodecXz.jl, group: TranscodingStreams}
+          - {user: JuliaIO, repo: CodecBzip2.jl, group: TranscodingStreams}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone Downstream
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
+          path: downstream
+      - name: Load this and run the downstream tests
+        shell: julia --color=yes --project=downstream {0}
+        run: |
+          using Pkg
+          try
+            # force it to use this PR's version of the package
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.update()
+            Pkg.test()  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine.
+            # It means we marked this as a breaking change, so we don't need to worry about.
+            # Mistakenly introducing a breaking change, as we have intentionally made one.
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
+          end

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -27,7 +27,7 @@ jobs:
           - {user: BioJulia, repo: Automa.jl, group: TranscodingStreams}
           - {user: BioJulia, repo: FASTX.jl, group: TranscodingStreams}
           - {user: diegozea, repo: MIToS.jl, group: TranscodingStreams}
-          - {user: apache, repo: arrow-julia.jl, group: TranscodingStreams}
+          - {user: apache, repo: arrow-julia, group: TranscodingStreams}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -22,7 +22,12 @@ jobs:
           - {user: JuliaIO, repo: CodecZstd.jl, group: TranscodingStreams}
           - {user: JuliaIO, repo: CodecBase.jl, group: TranscodingStreams}
           - {user: JuliaIO, repo: CodecXz.jl, group: TranscodingStreams}
+          - {user: JuliaIO, repo: ZipArchives.jl, group: TranscodingStreams}
           - {user: JuliaIO, repo: CodecBzip2.jl, group: TranscodingStreams}
+          - {user: BioJulia, repo: Automa.jl, group: TranscodingStreams}
+          - {user: BioJulia, repo: FASTX.jl, group: TranscodingStreams}
+          - {user: diegozea, repo: MIToS.jl, group: TranscodingStreams}
+          - {user: apache, repo: arrow-julia.jl, group: TranscodingStreams}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -27,7 +27,6 @@ jobs:
           - {user: BioJulia, repo: Automa.jl, group: TranscodingStreams}
           - {user: BioJulia, repo: FASTX.jl, group: TranscodingStreams}
           - {user: diegozea, repo: MIToS.jl, group: TranscodingStreams}
-          - {user: apache, repo: arrow-julia, group: TranscodingStreams}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -20,4 +20,4 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Pkg", "CodecZlib", "CodecXz", "CodecZstd", "CodecBase"]
+test = ["Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using TranscodingStreams
 using Test
-using Pkg
 
 if VERSION ≥ v"1.1"
     @test isempty(detect_unbound_args(TranscodingStreams; recursive=true))
@@ -126,8 +125,3 @@ end
 include("codecnoop.jl")
 include("codecinvalid.jl")
 include("codecquadruple.jl")
-
-# Test third-party codec packages.
-for pkg in ["CodecZlib", "CodecXz", "CodecZstd", "CodecBase"]
-    Pkg.test(pkg)
-end


### PR DESCRIPTION
This makes TS's tests quicker to run locally, and makes it easier to add more downstream tests without bloating the test environment.

Note to reviewers: Let's just see if this runs correctly with CI. If so, we can
* Add more downstream tests. No reason not to add lots, if their test suite is relative short IMO
* Merge this before e.g. #152 and rebase that onto master. Downstream tests will still fail for #152 due to compat reasons, but it will clearly show that TS's own tests pass.