### PR TITLE
Bump Documenter to 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 /Manifest.toml
 /docs/build/
+/docs/Manifest.toml

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,6 @@
 [deps]
-CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
-Documenter = "~0.27"
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,5 @@
 using Documenter
 using TranscodingStreams
-using CodecZlib
 
 makedocs(
     sitename="TranscodingStreams.jl",

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -10,8 +10,8 @@ TranscodingStream
 
 ```@docs
 TranscodingStream(codec::Codec, stream::IO)
-transcode(::Type{C}, args...) where {C<:Codec}
-transcode(::Codec, ::Buffer, ::Union{Buffer,Nothing})
+transcode
+TranscodingStreams.unsafe_transcode!
 
 TranscodingStreams.transcode!
 TranscodingStreams.TOKEN_END

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -97,17 +97,14 @@ Examples
 ```jldoctest
 julia> using TranscodingStreams
 
-julia> using CodecZlib
+julia> file = open(joinpath(dirname(dirname(pathof(TranscodingStreams))), "README.md"));
 
-julia> file = open(joinpath(dirname(pathof(CodecZlib)), "..", "test", "abra.gz"));
+julia> stream = NoopStream(file);
 
-julia> stream = TranscodingStream(GzipDecompressor(), file);
-
-julia> String(read(stream))
-"abracadabra"
+julia> readline(file)
+"TranscodingStreams.jl"
 
 julia> close(stream)
-
 ```
 """
 function TranscodingStream(codec::Codec, stream::IO;

--- a/src/transcode.jl
+++ b/src/transcode.jl
@@ -27,7 +27,6 @@ julia> decompressed = transcode(ZlibDecompressor, compressed);
 
 julia> String(decompressed)
 "abracadabra"
-
 ```
 """
 function Base.transcode(::Type{C}, args...) where {C<:Codec}


### PR DESCRIPTION
Also includes a series of fixes:
* Remove CodecZlib from doc deps
* Do not doctest using CodecZlib, a dep of this package
* Document `transcode`

Yet another yak to be shaved on the way ^^