### PR TITLE
Base.seek and Base.skip should return stream

### DIFF
--- a/src/noop.jl
+++ b/src/noop.jl
@@ -66,19 +66,19 @@ end
 function Base.seek(stream::NoopStream, pos::Integer)
     seek(stream.stream, pos)
     initbuffer!(stream.state.buffer1)
-    return
+    return stream
 end
 
 function Base.seekstart(stream::NoopStream)
     seekstart(stream.stream)
     initbuffer!(stream.state.buffer1)
-    return
+    return stream
 end
 
 function Base.seekend(stream::NoopStream)
     seekend(stream.stream)
     initbuffer!(stream.state.buffer1)
-    return
+    return stream
 end
 
 function Base.unsafe_read(stream::NoopStream, output::Ptr{UInt8}, nbytes::UInt)

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -252,7 +252,7 @@ function Base.skip(stream::TranscodingStream, offset::Integer)
         # TODO: support skip in write mode
         throw(ArgumentError("not in read mode"))
     end
-    return
+    return stream
 end
 
 """

--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -72,13 +72,13 @@
     close(stream)
 
     stream = TranscodingStream(Noop(), IOBuffer(b"foobarbaz"))
-    seek(stream, 2)
+    @test stream == seek(stream, 2)
     @test read(stream, 3) == b"oba"
     seek(stream, 0)
     @test read(stream, 3) == b"foo"
-    seekstart(stream)
+    @test stream == seekstart(stream)
     @test read(stream, 3) == b"foo"
-    seekend(stream)
+    @test stream == seekend(stream)
     @test eof(stream)
     close(stream)
 
@@ -97,7 +97,7 @@
     data = collect(0x00:0x0f)
     stream = TranscodingStream(Noop(), IOBuffer(data), bufsize=2)
     @test read(stream, UInt8) == data[1]
-    skip(stream, 4)
+    @test stream == skip(stream, 4)
     @test read(stream, UInt8) == data[6]
     skip(stream, 3)
     @test read(stream, UInt8) == data[10]


### PR DESCRIPTION
Continues #115 by having all `Base.seek`, `Base.seekend`, `Base.seekstart`, and `Base.skip` return the input stream.

> See https://github.com/JuliaLang/julia/blob/ae8452a9e0b973991c30f27beb2201db1b0ea0d3/base/iostream.jl#L164
> 
> This would make it more of a drop-in replacement for an IOStream.