### PR TITLE
Test if `seekstart` after `write` deletes data.

### DIFF
--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -333,4 +333,20 @@
             end
         end
     end
+
+    @testset "seekstart doesn't delete data" begin
+        sink = IOBuffer()
+        stream = NoopStream(sink, bufsize=16)
+        write(stream, "x")
+        # seekstart must not delete user data even if it errors.
+        try
+            seekstart(stream)
+        catch e
+            e isa ArgumentError || rethrow()
+        end
+        write(stream, TranscodingStreams.TOKEN_END)
+        flush(stream)
+        @test_broken take!(sink) == b"x"
+        close(stream)
+    end
 end

--- a/test/codecquadruple.jl
+++ b/test/codecquadruple.jl
@@ -107,4 +107,20 @@ end
             end
         end
     end
+
+    @testset "seekstart doesn't delete data" begin
+        sink = IOBuffer()
+        stream = TranscodingStream(QuadrupleCodec(), sink, bufsize=16)
+        write(stream, "x")
+        # seekstart must not delete user data even if it errors.
+        try
+            seekstart(stream)
+        catch e
+            e isa ArgumentError || rethrow()
+        end
+        write(stream, TranscodingStreams.TOKEN_END)
+        flush(stream)
+        @test_broken take!(sink) == b"xxxx"
+        close(stream)
+    end
 end


### PR DESCRIPTION
This PR adds tests showing that currently calling `seekstart` on a stream in write mode can silently delete data.