### PR TITLE
Tests: Do not assume empty vectors alias

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "TranscodingStreams"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/transcode.jl
+++ b/src/transcode.jl
@@ -122,7 +122,9 @@ function transcode!(
     codec::Codec,
     input::Buffer,
 )
-    @assert !Base.mightalias(input.data, output.data) "input and outbut buffers must be independent"
+    Base.mightalias(input.data, output.data) && error(
+        "input and outbut buffers must be independent"
+    )
     unsafe_transcode!(output, codec, input)
 end
 

--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -189,8 +189,9 @@
     @test transcode(Noop, data)  == data
     @test transcode(Noop, data) !== data
 
-    data = Vector{UInt8}()
+    data = UInt8[]
     @test TranscodingStreams.unsafe_transcode!(Noop(), data, data) == data
+    data = [0x01, 0x02]
     @test_throws AssertionError transcode(Noop(), data, data)
     data = b""
     @test transcode(Noop(), data)  == data

--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -192,7 +192,7 @@
     data = UInt8[]
     @test TranscodingStreams.unsafe_transcode!(Noop(), data, data) == data
     data = [0x01, 0x02]
-    @test_throws AssertionError transcode(Noop(), data, data)
+    @test_throws ErrorException transcode(Noop(), data, data)
     data = b""
     @test transcode(Noop(), data)  == data
     @test transcode(Noop(), data) !== data


### PR DESCRIPTION
Currently, TS uses Base.mightalias to throw an error if the two inputs to three- arg transcode alias.
Two problems here: Base.mightalias is internal, and the new memory PR to Julia changes aliasing of zero-length arrays.
The temporary fix for now is to remove the test that tests that zero-length arrays trips the Base.mightalias. Later, let's fix this properly by not relying on Base internals in TS tests.

This fixes TranscodingStreams' test errors on https://github.com/JuliaLang/julia/pull/51319