### PR TITLE
Safely error in generic `Base.seekstart` if in write mode.

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -282,9 +282,10 @@ end
 # ---------------
 
 function Base.seekstart(stream::TranscodingStream)
+    checkmode(stream)
     mode = stream.state.mode
-    @checkmode (:idle, :read, :write)
-    if mode == :read || mode == :write
+    @checkmode (:idle, :read)
+    if mode == :read
         callstartproc(stream, mode)
         emptybuffer!(stream.state.buffer1)
         emptybuffer!(stream.state.buffer2)

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -282,7 +282,6 @@ end
 # ---------------
 
 function Base.seekstart(stream::TranscodingStream)
-    checkmode(stream)
     mode = stream.state.mode
     @checkmode (:idle, :read)
     if mode == :read

--- a/test/codecquadruple.jl
+++ b/test/codecquadruple.jl
@@ -113,14 +113,10 @@ end
         stream = TranscodingStream(QuadrupleCodec(), sink, bufsize=16)
         write(stream, "x")
         # seekstart must not delete user data even if it errors.
-        try
-            seekstart(stream)
-        catch e
-            e isa ArgumentError || rethrow()
-        end
+        @test_throws ArgumentError seekstart(stream)
         write(stream, TranscodingStreams.TOKEN_END)
         flush(stream)
-        @test_broken take!(sink) == b"xxxx"
+        @test take!(sink) == b"xxxx"
         close(stream)
     end
 end

--- a/test/codecquadruple.jl
+++ b/test/codecquadruple.jl
@@ -108,6 +108,21 @@ end
         end
     end
 
+    @testset "seekstart" begin
+        data = Vector(b"abracadabra")
+        source = IOBuffer(data)
+        seekend(source)
+        stream = TranscodingStream(QuadrupleCodec(), source, bufsize=16)
+        @test seekstart(stream) == stream
+        @test position(stream) == 0
+        @test read(stream, 5) == b"aaaab"
+        @test position(stream) == 5
+        @test seekstart(stream) == stream
+        @test_broken position(stream) == 0
+        @test read(stream, 5) == b"aaaab"
+        @test_broken position(stream) == 5
+    end
+
     @testset "seekstart doesn't delete data" begin
         sink = IOBuffer()
         stream = TranscodingStream(QuadrupleCodec(), sink, bufsize=16)


### PR DESCRIPTION
This fixes one of the broken tests.