### PR TITLE
Add Random as test dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "TranscodingStreams"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.10.2"
+version = "0.10.3"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -22,6 +22,7 @@ julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Random"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using TranscodingStreams
+using Random
 using Test
 
 if VERSION ≥ v"1.1"


### PR DESCRIPTION
The TestExt extension is loaded when Random and Test are loaded, and is used in TS's tests. However, we forgot to load Random in the test suite. This accidentally worked before, because Random was in the sysimage, but this will not continue to be the case in the future.

See the comments in #152 