### PR TITLE
Flush buffer to avoid deleting data when seeking `NoopStream`

### DIFF
--- a/src/noop.jl
+++ b/src/noop.jl
@@ -64,18 +64,30 @@ function Base.position(stream::NoopStream)
 end
 
 function Base.seek(stream::NoopStream, pos::Integer)
+    mode = stream.state.mode
+    if mode === :write
+        flushbuffer(stream)
+    end
     seek(stream.stream, pos)
     initbuffer!(stream.buffer1)
     return stream
 end
 
 function Base.seekstart(stream::NoopStream)
+    mode = stream.state.mode
+    if mode === :write
+        flushbuffer(stream)
+    end
     seekstart(stream.stream)
     initbuffer!(stream.buffer1)
     return stream
 end
 
 function Base.seekend(stream::NoopStream)
+    mode = stream.state.mode
+    if mode === :write
+        flushbuffer(stream)
+    end
     seekend(stream.stream)
     initbuffer!(stream.buffer1)
     return stream

--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -339,15 +339,18 @@
         sink = IOBuffer()
         stream = NoopStream(sink, bufsize=16)
         write(stream, "x")
-        # seekstart must not delete user data even if it errors.
-        try
-            seekstart(stream)
-        catch e
-            e isa ArgumentError || rethrow()
-        end
-        write(stream, TranscodingStreams.TOKEN_END)
+        seekstart(stream)
         flush(stream)
-        @test_broken take!(sink) == b"x"
+        @test take!(sink) == b"x"
+        close(stream)
+
+        sink = IOBuffer()
+        stream = NoopStream(sink, bufsize=16)
+        write(stream, "abc")
+        seekstart(stream)
+        write(stream, "d")
+        flush(stream)
+        @test take!(sink) == b"dbc"
         close(stream)
     end
 end

--- a/test/codecquadruple.jl
+++ b/test/codecquadruple.jl
@@ -135,6 +135,19 @@ end
         close(stream)
     end
 
+    @testset "seekstart doesn't delete data in a NoopStream wrapped TranscodingStream" begin
+        sink = IOBuffer()
+        stream1 = TranscodingStream(QuadrupleCodec(), sink, bufsize=16)
+        stream2 = NoopStream(stream1, bufsize=16)
+        write(stream2, "x")
+        # seekstart must not delete user data even if it errors.
+        @test_throws ArgumentError seekstart(stream2)
+        write(stream2, TranscodingStreams.TOKEN_END)
+        flush(stream2)
+        @test take!(sink) == b"xxxx"
+        close(stream2)
+    end
+
     @testset "eof is true after write" begin
         sink = IOBuffer()
         stream = TranscodingStream(QuadrupleCodec(), sink, bufsize=16)

--- a/test/codecquadruple.jl
+++ b/test/codecquadruple.jl
@@ -124,28 +124,22 @@ end
     end
 
     @testset "seekstart doesn't delete data" begin
-        sink = IOBuffer()
-        stream = TranscodingStream(QuadrupleCodec(), sink, bufsize=16)
-        write(stream, "x")
-        # seekstart must not delete user data even if it errors.
-        @test_throws ArgumentError seekstart(stream)
-        write(stream, TranscodingStreams.TOKEN_END)
-        flush(stream)
-        @test take!(sink) == b"xxxx"
-        close(stream)
-    end
-
-    @testset "seekstart doesn't delete data in a NoopStream wrapped TranscodingStream" begin
-        sink = IOBuffer()
-        stream1 = TranscodingStream(QuadrupleCodec(), sink, bufsize=16)
-        stream2 = NoopStream(stream1, bufsize=16)
-        write(stream2, "x")
-        # seekstart must not delete user data even if it errors.
-        @test_throws ArgumentError seekstart(stream2)
-        write(stream2, TranscodingStreams.TOKEN_END)
-        flush(stream2)
-        @test take!(sink) == b"xxxx"
-        close(stream2)
+        for n in 0:3
+            sink = IOBuffer()
+            # wrap stream in NoopStream n times.
+            stream = foldl(
+                (s,_) -> NoopStream(s),
+                1:n;
+                init=TranscodingStream(QuadrupleCodec(), sink, bufsize=16)
+            )
+            write(stream, "x")
+            # seekstart must not delete user data even if it errors.
+            @test_throws ArgumentError seekstart(stream)
+            write(stream, TranscodingStreams.TOKEN_END)
+            flush(stream)
+            @test take!(sink) == b"xxxx"
+            close(stream)
+        end
     end
 
     @testset "eof is true after write" begin


### PR DESCRIPTION
This fixes one of the broken tests.

This also matches the pattern in `unsafe_write` where `flushbuffer` is called before the position in the underlying stream is adjusted if the stream is in `:write` mode.

https://github.com/JuliaIO/TranscodingStreams.jl/blob/db9b0edeb1838789454e2ec8fc0d182b02ba2e4a/src/noop.jl#L106-L117

