### PR TITLE
Remove `VERSION >= v"1.4"` checks

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -388,9 +388,7 @@ function Base.unsafe_read(stream::TranscodingStream, output::Ptr{UInt8}, nbytes:
         m = min(buffersize(buffer), p_end - p)
         copydata!(p, buffer, m)
         p += m
-        @static if VERSION >= v"1.4"
-            GC.safepoint()
-        end
+        GC.safepoint()
     end
     if p < p_end && eof(stream)
         throw(EOFError())
@@ -493,9 +491,7 @@ function Base.unsafe_write(stream::TranscodingStream, input::Ptr{UInt8}, nbytes:
         m = min(marginsize(buffer1), p_end - p)
         copydata!(buffer1, p, m)
         p += m
-        @static if VERSION >= v"1.4"
-            GC.safepoint()
-        end
+        GC.safepoint()
     end
     return Int(p - input)
 end
@@ -728,13 +724,9 @@ function writedata!(output::IO, input::Buffer)
         n = GC.@preserve input Base.unsafe_write(output, bufferptr(input), buffersize(input))
         consumed!(input, n)
         nwritten += n
-        @static if VERSION >= v"1.4"
-            GC.safepoint()
-        end
-    end
-    @static if VERSION >= v"1.4"
         GC.safepoint()
     end
+    GC.safepoint()
     return nwritten
 end
 


### PR DESCRIPTION
This package requires julia 1.6, so these checks are not needed now.