### PR TITLE
Make `Noop` `process` type stable

### DIFF
--- a/src/noop.jl
+++ b/src/noop.jl
@@ -120,7 +120,7 @@ initial_output_size(codec::Noop, input::Memory) = length(input)
 
 function process(codec::Noop, input::Memory, output::Memory, error::Error)
     iszero(length(input)) && return (0, 0, :end)
-    n = min(length(input), length(output))
+    n::Int = min(length(input), length(output))
     unsafe_copyto!(output.ptr, input.ptr, n)
     (n, n, :ok)
 end


### PR DESCRIPTION
Fixes #127

`process` should always return a `Tuple{Int,Int,Symbol}`, however, `length(::Memory)` returns an `UInt`