### PR TITLE
Safely error in generic `Base.seekend` if in write mode

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -310,8 +310,8 @@ end
 
 function Base.seekend(stream::TranscodingStream)
     mode = stream.state.mode
-    @checkmode (:idle, :read, :write)
-    if mode == :read || mode == :write
+    @checkmode (:idle, :read)
+    if mode == :read
         callstartproc(stream, mode)
         emptybuffer!(stream.buffer1)
         emptybuffer!(stream.buffer2)


### PR DESCRIPTION
This applies the fix in #159 to `seekend`

This prevents write buffered data from being deleted before it is saved.