### PR TITLE
Remove internal checkmode macro

### DIFF
--- a/src/noop.jl
+++ b/src/noop.jl
@@ -55,13 +55,14 @@ Note that this method may return a wrong position when
 """
 function Base.position(stream::NoopStream)
     mode = stream.state.mode
-    @checkmode (:idle, :read, :write)
     if mode === :idle
         return Int64(0)
     elseif mode === :write
         return position(stream.stream) + buffersize(stream.buffer1)
     elseif mode === :read
         return position(stream.stream) - buffersize(stream.buffer1)
+    else
+        throw_invalid_mode(mode)
     end
     @assert false "unreachable"
 end
@@ -146,19 +147,18 @@ end
 function stats(stream::NoopStream)
     state = stream.state
     mode = state.mode
-    @checkmode (:idle, :read, :write)
     buffer = stream.buffer1
     @assert buffer === stream.buffer2
-    if mode == :idle
+    if mode === :idle
         consumed = supplied = 0
-    elseif mode == :read
+    elseif mode === :read
         supplied = buffer.transcoded
         consumed = supplied - buffersize(buffer)
-    elseif mode == :write
+    elseif mode === :write
         supplied = buffer.transcoded + buffersize(buffer)
         consumed = buffer.transcoded
     else
-        @assert false "unreachable"
+        throw_invalid_mode(mode)
     end
     return Stats(consumed, supplied, supplied, supplied)
 end

--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -322,6 +322,8 @@
         end
         @test position(stream) == position(sink) == position(iob)
         close(stream)
+        @test_throws ArgumentError position(stream)
+        @test_throws ArgumentError TranscodingStreams.stats(stream)
         close(iob)
 
         mktemp() do path, sink

--- a/test/codecquadruple.jl
+++ b/test/codecquadruple.jl
@@ -95,6 +95,8 @@ end
             @test position(stream) == position(iob)
         end
         close(stream)
+        @test_throws ArgumentError position(stream)
+        @test_throws ArgumentError TranscodingStreams.stats(stream)
         close(iob)
 
         mktemp() do path, sink


### PR DESCRIPTION
I found this internal helper macro especially confusing because it breaks normal scoping rules.