### PR TITLE
Fix reading nested NoopStreams with sharebuf=false produces garbage data

### DIFF
--- a/src/noop.jl
+++ b/src/noop.jl
@@ -174,7 +174,7 @@ function fillbuffer(stream::NoopStream; eager::Bool = false)
     changemode!(stream, :read)
     buffer = stream.buffer1
     @assert buffer === stream.buffer2
-    if stream.stream isa TranscodingStream && buffer === stream.buffer1
+    if stream.stream isa TranscodingStream && buffer === stream.stream.buffer1
         # Delegate the operation when buffers are shared.
         return fillbuffer(stream.stream, eager = eager)
     end

--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -139,6 +139,19 @@
     @test read(stream) == b"foobar"
     close(stream)
 
+    stream = NoopStream(NoopStream(IOBuffer("foobar")); sharedbuf=false)
+    @test read(stream) == b"foobar"
+    close(stream)
+
+    stream = NoopStream(NoopStream(IOBuffer("foobar")); sharedbuf=false)
+    @test map(x->read(stream, UInt8), 1:6) == b"foobar"
+    @test eof(stream)
+    close(stream)
+
+    stream = NoopStream(NoopStream(NoopStream(IOBuffer("foobar")); sharedbuf=false))
+    @test read(stream) == b"foobar"
+    close(stream)
+
     # Two buffers are the same object.
     stream = NoopStream(IOBuffer("foo"))
     @test stream.buffer1 === stream.buffer2


### PR DESCRIPTION
Fixes #186 and adds some tests.

This seems to be a typo from https://github.com/JuliaIO/TranscodingStreams.jl/pull/168