### PR TITLE
Add basic Supposition.jl tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /Manifest.toml
 /docs/build/
 /docs/Manifest.toml
+/fuzz/test/
+/fuzz/Manifest.toml

--- a/fuzz/Project.toml
+++ b/fuzz/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Supposition = "5a0628fe-1738-4658-9b6d-0b7605a9755b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+
+[compat]
+Supposition = "0.3"

--- a/fuzz/fuzz.jl
+++ b/fuzz/fuzz.jl
@@ -1,0 +1,98 @@
+# Basic Supposition.jl tests to ensure nested streams can be read and written to.
+
+include("../test/codecdoubleframe.jl")
+using Supposition: Data, @composed, @check, event!
+
+datas = Data.Vectors(Data.Integers{UInt8}())
+
+# Possible kwargs for TranscodingStream constructor
+TS_kwarg = @composed (
+    bufsize=Data.Integers(1, 2^10),
+    stop_on_end=Data.Booleans(),
+    sharedbuf=Data.Booleans(),
+) -> (
+    if sharedbuf
+        # default sharedbuf
+        (;bufsize, stop_on_end)
+    else
+        # sharedbuf = false
+        (;bufsize, stop_on_end, sharedbuf)
+    end
+)
+
+# Possible NoopStream wrapper
+noop_wrapper = @composed (
+    kw=TS_kwarg,
+) -> (function noop_wrapper(io)
+    event!("noop", kw)
+    NoopStream(io; kw...)
+end)
+
+# Possible Encoder Decoder wrapper
+dec_enc_wrapper = @composed (
+    kw_enc=TS_kwarg,
+    kw_dec=TS_kwarg,
+) -> (function r_enc_dec_wrapper(io)
+    event!("encoder", kw_enc)
+    event!("decoder", kw_dec)
+    DoubleFrameDecoderStream(DoubleFrameEncoderStream(io; kw_enc...); kw_dec...)
+end)
+enc_dec_wrapper = @composed (
+    kw_enc=TS_kwarg,
+    kw_dec=TS_kwarg,
+) -> (function w_enc_dec_wrapper(io)
+    event!("decoder", kw_dec)
+    event!("encoder", kw_enc)
+    DoubleFrameEncoderStream(DoubleFrameDecoderStream(io; kw_dec...); kw_enc...)
+end)
+
+# Possible deeply nested wrappers
+read_wrapper = @composed (
+    w = Data.Vectors(noop_wrapper | dec_enc_wrapper; max_size=5)
+) -> (function read_wrapper(io)
+    event!("wrapping IOBuffer with:", nothing)
+    (∘(identity, w...))(io)
+end)
+write_wrapper = @composed (
+    w = Data.Vectors(noop_wrapper | enc_dec_wrapper; max_size=5)
+) -> (function write_wrapper(io)
+    event!("wrapping IOBuffer with:", nothing)
+    (∘(identity, w...))(io)
+end)
+
+@check max_examples=100000 function read_data(w=read_wrapper, data=datas)
+    stream = w(IOBuffer(data))
+    read(stream) == data || return false
+    eof(stream)
+end
+@check max_examples=100000 function read_byte_data(w=read_wrapper, data=datas)
+    stream = w(IOBuffer(data))
+    for i in 1:length(data)
+        read(stream, UInt8) == data[i] || return false
+    end
+    eof(stream)
+end
+
+# flush all nested streams and return final data
+function take_all(stream)
+    if stream isa Base.GenericIOBuffer
+        take!(stream)
+    else
+        write(stream, TranscodingStreams.TOKEN_END)
+        flush(stream)
+        take_all(stream.stream)
+    end
+end
+
+@check max_examples=100000 function write_data(w=write_wrapper, data=datas)
+    stream = w(IOBuffer())
+    write(stream, data) == length(data) || return false
+    take_all(stream) == data
+end
+@check max_examples=100000 function write_byte_data(w=write_wrapper, data=datas)
+    stream = w(IOBuffer())
+    for i in 1:length(data)
+        write(stream, data[i]) == 1 || return false
+    end
+    take_all(stream) == data
+end

--- a/fuzz/fuzz.jl
+++ b/fuzz/fuzz.jl
@@ -61,14 +61,20 @@ function wrap_stream(codecs_kws, io::IO)::IO
     end
 end
 
-@check db=false function read_byte_data(kws=read_codecs_kws, data=datas)
+@check function read_byte_data(
+        kws=read_codecs_kws,
+        data=datas,
+    )
     stream = wrap_stream(kws, IOBuffer(data))
     for i in eachindex(data)
         read(stream, UInt8) == data[i] || return false
     end
     eof(stream)
 end
-@check db=false function read_byte_data(kws=read_codecs_kws, data=datas)
+@check function read_data(
+        kws=read_codecs_kws,
+        data=datas,
+    )
     stream = wrap_stream(kws, IOBuffer(data))
     read(stream) == data || return false
     eof(stream)
@@ -87,7 +93,7 @@ end
 
 const write_codecs_kws = map(reverse, read_codecs_kws)
 
-@check db=false function write_data(
+@check function write_data(
         kws=write_codecs_kws,
         data=datas,
     )
@@ -95,7 +101,7 @@ const write_codecs_kws = map(reverse, read_codecs_kws)
     write(stream, data) == length(data) || return false
     take_all(stream) == data
 end
-@check db=false function write_byte_data(
+@check function write_byte_data(
         kws=write_codecs_kws,
         data=datas,
     )

--- a/fuzz/fuzz.jl
+++ b/fuzz/fuzz.jl
@@ -22,17 +22,14 @@ const datas = Data.Vectors(Data.Integers{UInt8}())
 const noopcodecs = Data.Vectors(Data.Just(Noop); max_size=3)
 
 function codecwrap(child)
-    map(child) do cs
+    map(child) do x
         DataType[
             DoubleFrameEncoder;
-            cs;
+            x;
             DoubleFrameDecoder;
         ]
-    end | map(child) do cs
-        DataType[
-            cs;
-            produce!(child);
-        ]
+    end | map(Data.Vectors(child; min_size=2, max_size=2)) do x
+        reduce(vcat, x)
     end
 end
 

--- a/test/codecdoubleframe.jl
+++ b/test/codecdoubleframe.jl
@@ -243,6 +243,26 @@ DoubleFrameDecoderStream(stream::IO; kwargs...) = TranscodingStream(DoubleFrameD
         @test String(take!(sink)) == "[  ][ aabbcc ][ ddee ]"
     end
 
+    @testset "stop_on_end=true in nested streams" begin
+        s1 = DoubleFrameDecoderStream(DoubleFrameEncoderStream(
+            DoubleFrameDecoderStream(
+                DoubleFrameEncoderStream(IOBuffer(b"")); 
+                stop_on_end=true,
+            )
+        ))
+        @test_broken read(s1) == b""
+        @test_broken eof(s1)
+
+        s2 = NoopStream(
+            DoubleFrameDecoderStream(
+                DoubleFrameEncoderStream(IOBuffer(b"")); 
+                stop_on_end=true,
+            )
+        )
+        @test read(s2) == b""
+        @test_broken eof(s2)
+    end
+
     test_roundtrip_read(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
     test_roundtrip_write(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
     test_roundtrip_lines(DoubleFrameEncoderStream, DoubleFrameDecoderStream)


### PR DESCRIPTION
These tests found a bug with reading data from nested streams if `stop_on_end=true` is set somewhere in the stack.

To run the `fuzz.jl` tests run:
```sh
cd fuzz
julia --project -e 'using Pkg; pkg"dev .."; pkg"instantiate";'
julia --project fuzz.jl
```

@Seelengrab thank you for making Supposition.jl, this is my first attempt at using it. I think I'm using the `@composed` macro correctly, but is there something obvious I missed to make these tests nicer?

Currently, I get the following messages showing counterexample nested streams:

```julia
Events occured: 4
    wrapping IOBuffer with:
        nothing
    encoder
        (bufsize = 1, stop_on_end = false, sharedbuf = false)
    decoder
        (bufsize = 1, stop_on_end = true, sharedbuf = false)
    noop
        (bufsize = 1, stop_on_end = false)
┌ Error: Property errored!
│   Description = "read_data"
│   Example = (w = var"#read_wrapper#10"{Vector{Union{var"#noop_wrapper#7", var"#r_enc_dec_wrapper#8"}}}(Union{var"#noop_wrapper#7", var"#r_enc_dec_wrapper#8"}[var"#noop_wrapper#7"{@NamedTuple{bufsize::Int64, stop_on_end::Bool}}((bufsize = 1, stop_on_end = false)), var"#r_enc_dec_wrapper#8"{@NamedTuple{bufsize::Int64, stop_on_end::Bool, sharedbuf::Bool}, @NamedTuple{bufsize::Int64, stop_on_end::Bool, sharedbuf::Bool}}((bufsize = 1, stop_on_end = false, sharedbuf = false), (bufsize = 1, stop_on_end = true, sharedbuf = false))]), data = UInt8[])
│   exception =
│    ArgumentError: cannot change the mode from stop to read
│    Stacktrace:
│      [1] changemode!(stream::TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}, newmode::Symbol)
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:788
│      [2] fillbuffer(stream::TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}; eager::Bool)
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:597
│      [3] fillbuffer
│        @ ~/juliadev/TranscodingStreams/src/stream.jl:596 [inlined]
│      [4] fillbuffer(stream::NoopStream{TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}}; eager::Bool)
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/noop.jl:179
│      [5] fillbuffer
│        @ ~/juliadev/TranscodingStreams/src/noop.jl:173 [inlined]
│      [6] sloweof(stream::NoopStream{TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}})
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:210
│      [7] eof(stream::NoopStream{TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}})
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:201
│      [8] read_data(w::var"#read_wrapper#10"{Vector{Union{var"#noop_wrapper#7", var"#r_enc_dec_wrapper#8"}}}, data::Vector{UInt8})
│        @ Main ~/juliadev/TranscodingStreams/fuzz/fuzz.jl:66
│      [9] var"##read_data__run#239"(237::Supposition.TestCase{Xoshiro})
│        @ Main ~/.julia/packages/Supposition/KpGkN/src/api.jl:240
│     [10] macro expansion
│        @ ~/.julia/packages/Supposition/KpGkN/src/teststate.jl:38 [inlined]
└ @ Supposition ~/.julia/packages/Supposition/KpGkN/src/testset.jl:287
Test Summary: | Error  Total   Time
read_data     |     1      1  14.0s
Events occured: 6
    wrapping IOBuffer with:
        nothing
    encoder
        (bufsize = 1, stop_on_end = false, sharedbuf = false)
    decoder
        (bufsize = 1, stop_on_end = true, sharedbuf = false)
    noop
        (bufsize = 1, stop_on_end = false)
    encoder
        (bufsize = 336, stop_on_end = false, sharedbuf = false)
    decoder
        (bufsize = 782, stop_on_end = true)
┌ Error: Property errored!
│   Description = "read_byte_data"
│   Example = (w = var"#read_wrapper#10"{Vector{Union{var"#noop_wrapper#7", var"#r_enc_dec_wrapper#8"}}}(Union{var"#noop_wrapper#7", var"#r_enc_dec_wrapper#8"}[var"#r_enc_dec_wrapper#8"{@NamedTuple{bufsize::Int64, stop_on_end::Bool, sharedbuf::Bool}, @NamedTuple{bufsize::Int64, stop_on_end::Bool}}((bufsize = 336, stop_on_end = false, sharedbuf = false), (bufsize = 782, stop_on_end = true)), var"#noop_wrapper#7"{@NamedTuple{bufsize::Int64, stop_on_end::Bool}}((bufsize = 1, stop_on_end = false)), var"#r_enc_dec_wrapper#8"{@NamedTuple{bufsize::Int64, stop_on_end::Bool, sharedbuf::Bool}, @NamedTuple{bufsize::Int64, stop_on_end::Bool, sharedbuf::Bool}}((bufsize = 1, stop_on_end = false, sharedbuf = false), (bufsize = 1, stop_on_end = true, sharedbuf = false))]), data = UInt8[])
│   exception =
│    ArgumentError: cannot change the mode from stop to read
│    Stacktrace:
│      [1] changemode!(stream::TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}, newmode::Symbol)
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:788
│      [2] fillbuffer(stream::TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}; eager::Bool)
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:597
│      [3] fillbuffer
│        @ ~/juliadev/TranscodingStreams/src/stream.jl:596 [inlined]
│      [4] fillbuffer(stream::NoopStream{TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}}; eager::Bool)
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/noop.jl:179
│      [5] fillbuffer
│        @ ~/juliadev/TranscodingStreams/src/noop.jl:173 [inlined]
│      [6] sloweof(stream::NoopStream{TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}})
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:210
│      [7] eof
│        @ ~/juliadev/TranscodingStreams/src/stream.jl:201 [inlined]
│      [8] readdata!(input::NoopStream{TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}}, output::TranscodingStreams.Buffer)
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:707
│      [9] fillbuffer(stream::TranscodingStream{DoubleFrameEncoder, NoopStream{TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}}}; eager::Bool)
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:609
│     [10] fillbuffer
│        @ ~/juliadev/TranscodingStreams/src/stream.jl:596 [inlined]
│     [11] readdata!(input::TranscodingStream{DoubleFrameEncoder, NoopStream{TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}}}, output::TranscodingStreams.Buffer)
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:703
│     [12] fillbuffer(stream::TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, NoopStream{TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}}}}; eager::Bool)
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:609
│     [13] fillbuffer
│        @ ~/juliadev/TranscodingStreams/src/stream.jl:596 [inlined]
│     [14] sloweof(stream::TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, NoopStream{TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}}}})
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:210
│     [15] eof(stream::TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, NoopStream{TranscodingStream{DoubleFrameDecoder, TranscodingStream{DoubleFrameEncoder, IOBuffer}}}}})
│        @ TranscodingStreams ~/juliadev/TranscodingStreams/src/stream.jl:201
│     [16] read_byte_data(w::var"#read_wrapper#10"{Vector{Union{var"#noop_wrapper#7", var"#r_enc_dec_wrapper#8"}}}, data::Vector{UInt8})
│        @ Main ~/juliadev/TranscodingStreams/fuzz/fuzz.jl:73
│     [17] var"##read_byte_data__run#262"(260::Supposition.TestCase{Xoshiro})
│        @ Main ~/.julia/packages/Supposition/KpGkN/src/api.jl:240
│     [18] macro expansion
│        @ ~/.julia/packages/Supposition/KpGkN/src/teststate.jl:38 [inlined]
└ @ Supposition ~/.julia/packages/Supposition/KpGkN/src/testset.jl:287
Test Summary:  | Error  Total  Time
read_byte_data |     1      1  9.6s
Test Summary: | Pass  Total     Time
write_data    |    1      1  1m20.2s
Test Summary:   | Pass  Total   Time
write_byte_data |    1      1  35.2s
```