### PR TITLE
Fix reading nested streams with `stop_on_end=true` set.

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -707,10 +707,15 @@ end
 
 # Read as much data as possbile from `input` to the margin of `output`.
 # This function will not block if `input` has buffered data.
-function readdata!(input::IO, output::Buffer)
+function readdata!(input::IO, output::Buffer)::Int
     if input isa TranscodingStream && input.buffer1 === output
         # Delegate the operation to the underlying stream for shared buffers.
-        return fillbuffer(input)
+        mode::Symbol = input.state.mode
+        if mode === :idle || mode === :read
+            return fillbuffer(input)
+        else
+            return 0
+        end
     end
     nread::Int = 0
     navail = bytesavailable(input)

--- a/test/codecdoubleframe.jl
+++ b/test/codecdoubleframe.jl
@@ -250,8 +250,8 @@ DoubleFrameDecoderStream(stream::IO; kwargs...) = TranscodingStream(DoubleFrameD
                 stop_on_end=true,
             )
         ))
-        @test_broken read(s1) == b""
-        @test_broken eof(s1)
+        @test read(s1) == b""
+        @test eof(s1)
 
         s2 = NoopStream(
             DoubleFrameDecoderStream(
@@ -260,7 +260,7 @@ DoubleFrameDecoderStream(stream::IO; kwargs...) = TranscodingStream(DoubleFrameD
             )
         )
         @test read(s2) == b""
-        @test_broken eof(s2)
+        @test eof(s2)
     end
 
     test_roundtrip_read(DoubleFrameEncoderStream, DoubleFrameDecoderStream)


### PR DESCRIPTION
This PR adds checks to make sure `fillbuffer` is only called on the underlying stream if it is in the right mode.

With this change, the tests added in #190 pass.