### PR TITLE
Avoid infinite loop in `readbytes!(s, UInt8[], 1)`

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -412,7 +412,7 @@ function Base.readbytes!(stream::TranscodingStream, b::DenseArray{UInt8}, nb=len
     resized = false
     while filled < nb && !eof(stream)
         if length(b) == filled
-            resize!(b, min(length(b) * 2, nb))
+            resize!(b, min(max(length(b) * 2, 32), nb))
             resized = true
         end
         filled += GC.@preserve b unsafe_read(stream, pointer(b, filled+1), min(length(b), nb)-filled)

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -412,7 +412,7 @@ function Base.readbytes!(stream::TranscodingStream, b::DenseArray{UInt8}, nb=len
     resized = false
     while filled < nb && !eof(stream)
         if length(b) == filled
-            resize!(b, min(max(length(b) * 2, 32), nb))
+            resize!(b, min(max(length(b) * 2, 8), nb))
             resized = true
         end
         filled += GC.@preserve b unsafe_read(stream, pointer(b, filled+1), min(length(b), nb)-filled)

--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -195,6 +195,14 @@
     @test readavailable(stream) == b"oobar"
     close(stream)
 
+    # issue #193
+    stream = NoopStream(IOBuffer("foobar"))
+    data = UInt8[]
+    @test readbytes!(stream, data, 1) === 1
+    @test data == b"f"
+    @test position(stream) == 1
+    close(stream)
+
     data = b""
     @test transcode(Noop, data)  == data
     @test transcode(Noop, data) !== data


### PR DESCRIPTION
Fixes #193 
This fixes the edge case of calling `readbytes!` with an empty `b` but non-zero `nb` by resizing `b` initially to 32 bytes if `b` is too small.