### PR TITLE
Bump version to 0.10.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "TranscodingStreams"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.10.6"
+version = "0.10.7"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
This new version contains a few minor bug fixes since 0.10.6

It also has a new Supposition.jl test script in the `fuzz` directory.

Here are the changes compared to 0.10.6 https://github.com/JuliaIO/TranscodingStreams.jl/compare/3c187f4..9d69586