### PR TITLE
Remove unneeded `Base.unsafe_read` `NoopStream` method

### DIFF
--- a/src/noop.jl
+++ b/src/noop.jl
@@ -97,28 +97,6 @@ function Base.seekend(stream::NoopStream)
     return stream
 end
 
-function Base.unsafe_read(stream::NoopStream, output::Ptr{UInt8}, nbytes::UInt)
-    changemode!(stream, :read)
-    buffer = stream.buffer1
-    p = output
-    p_end = output + nbytes
-    while p < p_end && !eof(stream)
-        if buffersize(buffer) > 0
-            m = min(buffersize(buffer), p_end - p)
-            copydata!(p, buffer, m)
-        else
-            # directly read data from the underlying stream
-            m = p_end - p
-            Base.unsafe_read(stream.stream, p, m)
-        end
-        p += m
-    end
-    if p < p_end && eof(stream)
-        throw(EOFError())
-    end
-    return
-end
-
 function Base.unsafe_write(stream::NoopStream, input::Ptr{UInt8}, nbytes::UInt)
     changemode!(stream, :write)
     buffer = stream.buffer1

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -400,7 +400,7 @@ function Base.unsafe_read(stream::TranscodingStream, output::Ptr{UInt8}, nbytes:
         p += m
         GC.safepoint()
     end
-    if p < p_end && eof(stream)
+    if p < p_end
         throw(EOFError())
     end
     return


### PR DESCRIPTION
From what I can tell the `# directly read data from the underlying stream` branch is unreachable, so this method is the same as the generic one for `TranscodingStream`.

This PR also removes a redundant call to `eof` from `Base.unsafe_read(stream::TranscodingStream`:
To exit the `while` loop with `p < p_end` true, `eof(stream)` must have returned true on line 397. So there is no reason to check `eof` again on line 403.