### PR TITLE
Allow non 1-based arrays in `readbytes!`

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -412,7 +412,7 @@ function Base.readbytes!(stream::TranscodingStream, b::DenseArray{UInt8}, nb=len
     resized = false
     while filled < nb && !eof(stream)
         if length(b) == filled
-            resize!(b, min(max(length(b) * Int64(2), 8), nb))
+            resize!(b, min(max(length(b) * 2, 8), nb))
             resized = true
         end
         filled += GC.@preserve b unsafe_read(stream, pointer(b, filled+firstindex(b)), min(length(b), nb)-filled)

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -412,10 +412,10 @@ function Base.readbytes!(stream::TranscodingStream, b::DenseArray{UInt8}, nb=len
     resized = false
     while filled < nb && !eof(stream)
         if length(b) == filled
-            resize!(b, min(max(length(b) * 2, 8), nb))
+            resize!(b, min(max(length(b) * Int64(2), 8), nb))
             resized = true
         end
-        filled += GC.@preserve b unsafe_read(stream, pointer(b, filled+1), min(length(b), nb)-filled)
+        filled += GC.@preserve b unsafe_read(stream, pointer(b, filled+firstindex(b)), min(length(b), nb)-filled)
     end
     if resized
         resize!(b, filled)


### PR DESCRIPTION
This PR changes a hardcoded `1` to `firstindex` in the `readbytes!` function.

I can't test this with OffsetArrays.jl because an `OffsetArray` isn't a `DenseArray`