### PR TITLE
Unread extra data when stopping

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -157,7 +157,8 @@ eof(stream)   #> true
 In the case where you need to reuse the wrapped stream, the code above must be
 slightly modified because the transcoding stream may read more bytes than
 necessary from the wrapped stream. Wrapping the stream with `NoopStream` solves
-the problem because adjacent transcoding streams share the same buffer.
+the problem because any extra data read after the end of the chunk will be 
+stored back in the internal buffer of the wrapped transcoding stream.
 ```julia
 using CodecZlib
 using TranscodingStreams

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -700,6 +700,10 @@ function callprocess(stream::TranscodingStream, inbuf::Buffer, outbuf::Buffer)
         makemargin!(outbuf, max(16, marginsize(outbuf) * 2))
     elseif state.code == :end && state.stop_on_end
         if stream.state.mode == :read
+            if stream.stream isa TranscodingStream && !has_sharedbuf(stream) && !iszero(buffersize(inbuf))
+                # unread data to match behavior if inbuf was shared.
+                GC.@preserve inbuf unsafe_unread(stream.stream, bufferptr(inbuf), buffersize(inbuf))
+            end
             changemode!(stream, :stop)
         end
     end


### PR DESCRIPTION
This PR makes the behavior of `stop_on_end=true` consistent when wrapping another `TranscodingStream` with `sharedbuf=false` or `sharedbuf=true`.