### PR TITLE
Add a GC.@preserve when calling unsafe_transcode!

### DIFF
--- a/src/transcode.jl
+++ b/src/transcode.jl
@@ -125,7 +125,8 @@ function transcode!(
     Base.mightalias(input.data, output.data) && error(
         "input and outbut buffers must be independent"
     )
-    unsafe_transcode!(output, codec, input)
+    # GC.@preserve since unsafe_transcode! may convert to raw pointers
+    GC.@preserve input output codec unsafe_transcode!(output, codec, input)
 end
 
 """


### PR DESCRIPTION
Add `GC.@preserve` when calling `unsafe_transcode!` since buffer to memory conversions involve raw pointer conversions. 
