### PR TITLE
Add `test_roundtrip_seekstart` function to help test that `seekstart` resets the state of the codec

### DIFF
--- a/ext/TestExt.jl
+++ b/ext/TestExt.jl
@@ -68,7 +68,7 @@ function TranscodingStreams.test_roundtrip_seekstart(encoder, decoder)
         data = rand(alpha, n)
         file = IOBuffer(data)
         stream = decoder(encoder(file))
-        for m in vcat(0:min(n,20), sort!(rand(0:n, 10)))
+        for m in vcat(0:min(n,20), rand(0:n, 10))
             Test.@test read(stream, m) == @view(data[1:m])
             seekstart(stream)
         end

--- a/ext/TestExt.jl
+++ b/ext/TestExt.jl
@@ -125,4 +125,23 @@ function TranscodingStreams.test_chunked_write(Encoder, Decoder)
     finalize(encoder)
 end
 
+# Test that seekstart resets the state of the codec.
+function TranscodingStreams.test_seekstart(encoder, decoder)
+    seed!(TEST_RANDOM_SEED)
+    for n in vcat(0:30, sort!(rand(500:100_000, 30))), alpha in (0x00:0xff, 0x00:0x0f)
+        data = rand(alpha, n)
+        file = IOBuffer(data)
+        stream = decoder(encoder(file))
+        for m in vcat(0:min(n,20), sort!(rand(0:n, 10)))
+            Test.@test read(stream, m) == @view(data[1:m])
+            seekstart(stream)
+        end
+        seekstart(stream)
+        Test.@test read(stream) == data
+        seekstart(stream)
+        Test.@test read(stream) == data
+        close(stream)
+    end
+end
+
 end # module

--- a/ext/TestExt.jl
+++ b/ext/TestExt.jl
@@ -62,6 +62,24 @@ function TranscodingStreams.test_roundtrip_lines(encoder, decoder)
     Test.@test hash(lines) == hash(readlines(decoder(buf)))
 end
 
+function TranscodingStreams.test_roundtrip_seekstart(encoder, decoder)
+    seed!(TEST_RANDOM_SEED)
+    for n in vcat(0:30, sort!(rand(500:100_000, 30))), alpha in (0x00:0xff, 0x00:0x0f)
+        data = rand(alpha, n)
+        file = IOBuffer(data)
+        stream = decoder(encoder(file))
+        for m in vcat(0:min(n,20), sort!(rand(0:n, 10)))
+            Test.@test read(stream, m) == @view(data[1:m])
+            seekstart(stream)
+        end
+        seekstart(stream)
+        Test.@test read(stream) == data
+        seekstart(stream)
+        Test.@test read(stream) == data
+        close(stream)
+    end
+end
+
 function TranscodingStreams.test_roundtrip_fileio(Encoder, Decoder)
     data = b"""
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sit amet tempus felis. Etiam molestie urna placerat iaculis pellentesque. Maecenas porttitor et dolor vitae posuere. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc eget nibh quam. Nullam aliquet interdum fringilla. Duis facilisis, lectus in consectetur varius, lorem sem tempor diam, nec auctor tellus nibh sit amet sapien. In ex nunc, elementum eget facilisis ut, luctus eu orci. Sed sapien urna, accumsan et elit non, auctor pretium massa. Phasellus consectetur nisi suscipit blandit aliquam. Nulla facilisi. Mauris pellentesque sem sit amet mi vestibulum eleifend. Nulla faucibus orci ac lorem efficitur, et blandit orci interdum. Aenean posuere ultrices ex sed rhoncus. Donec malesuada mollis sem, sed varius nunc sodales sed. Curabitur lobortis non justo non tristique.
@@ -123,25 +141,6 @@ function TranscodingStreams.test_chunked_write(Encoder, Decoder)
         Test.@test ok
     end
     finalize(encoder)
-end
-
-# Test that seekstart resets the state of the codec.
-function TranscodingStreams.test_seekstart(encoder, decoder)
-    seed!(TEST_RANDOM_SEED)
-    for n in vcat(0:30, sort!(rand(500:100_000, 30))), alpha in (0x00:0xff, 0x00:0x0f)
-        data = rand(alpha, n)
-        file = IOBuffer(data)
-        stream = decoder(encoder(file))
-        for m in vcat(0:min(n,20), sort!(rand(0:n, 10)))
-            Test.@test read(stream, m) == @view(data[1:m])
-            seekstart(stream)
-        end
-        seekstart(stream)
-        Test.@test read(stream) == data
-        seekstart(stream)
-        Test.@test read(stream) == data
-        close(stream)
-    end
 end
 
 end # module

--- a/src/TranscodingStreams.jl
+++ b/src/TranscodingStreams.jl
@@ -21,10 +21,10 @@ function test_roundtrip_read end
 function test_roundtrip_write end
 function test_roundtrip_transcode end
 function test_roundtrip_lines end
+function test_roundtrip_seekstart end
 function test_roundtrip_fileio end
 function test_chunked_read end
 function test_chunked_write end
-function test_seekstart end
 
 if !isdefined(Base, :get_extension)
     include("../ext/TestExt.jl")

--- a/src/TranscodingStreams.jl
+++ b/src/TranscodingStreams.jl
@@ -24,6 +24,7 @@ function test_roundtrip_lines end
 function test_roundtrip_fileio end
 function test_chunked_read end
 function test_chunked_write end
+function test_seekstart end
 
 if !isdefined(Base, :get_extension)
     include("../ext/TestExt.jl")

--- a/test/codecdoubleframe.jl
+++ b/test/codecdoubleframe.jl
@@ -7,11 +7,11 @@ using TranscodingStreams:
     test_roundtrip_read,
     test_roundtrip_write,
     test_roundtrip_lines,
+    test_roundtrip_seekstart,
     test_roundtrip_transcode,
     test_roundtrip_fileio,
     test_chunked_read,
     test_chunked_write,
-    test_seekstart,
     Error
 
 # An insane codec for testing the codec APIs.
@@ -306,7 +306,7 @@ DoubleFrameDecoderStream(stream::IO; kwargs...) = TranscodingStream(DoubleFrameD
     test_roundtrip_read(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
     test_roundtrip_write(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
     test_roundtrip_lines(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
-    test_seekstart(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
+    test_roundtrip_seekstart(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
     test_roundtrip_transcode(DoubleFrameEncoder, DoubleFrameDecoder)
     test_roundtrip_fileio(DoubleFrameEncoder, DoubleFrameDecoder)
     test_chunked_read(DoubleFrameEncoder, DoubleFrameDecoder)

--- a/test/codecdoubleframe.jl
+++ b/test/codecdoubleframe.jl
@@ -11,6 +11,7 @@ using TranscodingStreams:
     test_roundtrip_fileio,
     test_chunked_read,
     test_chunked_write,
+    test_seekstart,
     Error
 
 # An insane codec for testing the codec APIs.
@@ -305,6 +306,7 @@ DoubleFrameDecoderStream(stream::IO; kwargs...) = TranscodingStream(DoubleFrameD
     test_roundtrip_read(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
     test_roundtrip_write(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
     test_roundtrip_lines(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
+    test_seekstart(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
     test_roundtrip_transcode(DoubleFrameEncoder, DoubleFrameDecoder)
     test_roundtrip_fileio(DoubleFrameEncoder, DoubleFrameDecoder)
     test_chunked_read(DoubleFrameEncoder, DoubleFrameDecoder)

--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -254,6 +254,7 @@ using FillArrays: Zeros
     TranscodingStreams.test_roundtrip_read(NoopStream, NoopStream)
     TranscodingStreams.test_roundtrip_write(NoopStream, NoopStream)
     TranscodingStreams.test_roundtrip_lines(NoopStream, NoopStream)
+    TranscodingStreams.test_seekstart(NoopStream, NoopStream)
 
     @testset "switch write => read" begin
         stream = NoopStream(IOBuffer(collect(b"foobar"), read=true, write=true))

--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -254,7 +254,7 @@ using FillArrays: Zeros
     TranscodingStreams.test_roundtrip_read(NoopStream, NoopStream)
     TranscodingStreams.test_roundtrip_write(NoopStream, NoopStream)
     TranscodingStreams.test_roundtrip_lines(NoopStream, NoopStream)
-    TranscodingStreams.test_seekstart(NoopStream, NoopStream)
+    TranscodingStreams.test_roundtrip_seekstart(NoopStream, NoopStream)
 
     @testset "switch write => read" begin
         stream = NoopStream(IOBuffer(collect(b"foobar"), read=true, write=true))


### PR DESCRIPTION
Fixes #217 