### PR TITLE
Remove `Memory(::ByteData)` constructor

### DIFF
--- a/src/TranscodingStreams.jl
+++ b/src/TranscodingStreams.jl
@@ -16,6 +16,7 @@ include("stream.jl")
 include("io.jl")
 include("noop.jl")
 include("transcode.jl")
+include("deprecated.jl")
 
 function test_roundtrip_read end
 function test_roundtrip_write end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,1 @@
+Base.@deprecate Memory(data::ByteData) Memory(pointer(data), sizeof(data)) false

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -11,6 +11,10 @@ struct Memory
     size::UInt
 end
 
+function Memory(data::Vector{UInt8})
+    return Memory(pointer(data), sizeof(data))
+end
+
 @inline function Base.length(mem::Memory)
     return mem.size
 end

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -11,10 +11,6 @@ struct Memory
     size::UInt
 end
 
-function Memory(data::ByteData)
-    return Memory(pointer(data), sizeof(data))
-end
-
 @inline function Base.length(mem::Memory)
     return mem.size
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,31 +72,33 @@ end
 
 @testset "Memory" begin
     data = Vector{UInt8}(b"foobar")
-    mem = TranscodingStreams.Memory(pointer(data), sizeof(data))
-    @test mem isa TranscodingStreams.Memory
-    @test mem.ptr === pointer(data)
-    @test mem.size === length(mem) === UInt(sizeof(data))
-    @test lastindex(mem) === 6
-    @test mem[1] === UInt8('f')
-    @test mem[2] === UInt8('o')
-    @test mem[3] === UInt8('o')
-    @test mem[4] === UInt8('b')
-    @test mem[5] === UInt8('a')
-    @test mem[6] === UInt8('r')
-    @test_throws BoundsError mem[7]
-    @test_throws BoundsError mem[0]
-    mem[1] = UInt8('z')
-    @test mem[1] === UInt8('z')
-    mem[3] = UInt8('!')
-    @test mem[3] === UInt8('!')
-    @test_throws BoundsError mem[7] = 0x00
-    @test_throws BoundsError mem[0] = 0x00
+    GC.@preserve data let mem = TranscodingStreams.Memory(pointer(data), sizeof(data))
+        @test mem isa TranscodingStreams.Memory
+        @test mem.ptr === pointer(data)
+        @test mem.size === length(mem) === UInt(sizeof(data))
+        @test lastindex(mem) === 6
+        @test mem[1] === UInt8('f')
+        @test mem[2] === UInt8('o')
+        @test mem[3] === UInt8('o')
+        @test mem[4] === UInt8('b')
+        @test mem[5] === UInt8('a')
+        @test mem[6] === UInt8('r')
+        @test_throws BoundsError mem[7]
+        @test_throws BoundsError mem[0]
+        mem[1] = UInt8('z')
+        @test mem[1] === UInt8('z')
+        mem[3] = UInt8('!')
+        @test mem[3] === UInt8('!')
+        @test_throws BoundsError mem[7] = 0x00
+        @test_throws BoundsError mem[0] = 0x00
+    end
 
     data = Vector{UInt8}(b"foobar")
-    mem = TranscodingStreams.Memory(data)
-    @test mem isa TranscodingStreams.Memory
-    @test mem.ptr == pointer(data)
-    @test mem.size == sizeof(data)
+    GC.@preserve data let mem = TranscodingStreams.Memory(pointer(data), sizeof(data))
+        @test mem isa TranscodingStreams.Memory
+        @test mem.ptr == pointer(data)
+        @test mem.size == sizeof(data)
+    end
 end
 
 @testset "Stats" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,7 +94,7 @@ end
     end
 
     data = Vector{UInt8}(b"foobar")
-    GC.@preserve data let mem = TranscodingStreams.Memory(pointer(data), sizeof(data))
+    GC.@preserve data let mem = TranscodingStreams.Memory(data)
         @test mem isa TranscodingStreams.Memory
         @test mem.ptr == pointer(data)
         @test mem.size == sizeof(data)


### PR DESCRIPTION
Fixes #211

https://github.com/JuliaIO/TranscodingStreams.jl/blob/8fdabeda88199cd4298d9cba597e006b1af7655a/src/TranscodingStreams.jl#L8

This may cause issues as `CodeUnits` may not be stored densely in memory.
Ref: https://github.com/JuliaLang/julia/pull/54002