### PR TITLE
Add `GC.@preserve` when using pointers

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -178,7 +178,7 @@ using CodecZlib
 
 function decompress(input, output)
     buffer = Vector{UInt8}(undef, 16 * 1024)
-    while !eof(input)
+    GC.@preserve buffer while !eof(input)
         n = min(bytesavailable(input), length(buffer))
         unsafe_read(input, pointer(buffer), n)
         unsafe_write(output, pointer(buffer), n)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -11,6 +11,7 @@ struct Memory
     size::UInt
 end
 
+# TODO remove this method
 function Memory(data::ByteData)
     return Memory(pointer(data), sizeof(data))
 end

--- a/test/codecquadruple.jl
+++ b/test/codecquadruple.jl
@@ -81,7 +81,8 @@ end
     close(stream2)
 
     stream = TranscodingStream(QuadrupleCodec(), IOBuffer("foo"))
-    @test_throws EOFError unsafe_read(stream, pointer(Vector{UInt8}(undef, 13)), 13)
+    data = Vector{UInt8}(undef, 13)
+    @test_throws EOFError GC.@preserve data unsafe_read(stream, pointer(data), 13)
     close(stream)
 
     @testset "position" begin


### PR DESCRIPTION
This PR adds `GC.@preserve` around places pointers are used.