### PR TITLE
Fix peek Char

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -314,7 +314,7 @@ end
 # Read Functions
 # --------------
 
-function Base.read(stream::TranscodingStream, ::Type{UInt8})
+function Base.peek(stream::TranscodingStream, ::Type{UInt8})::UInt8
     # eof and ready_to_read! are inlined here because ready_to_read! is very slow and eof is broken
     eof = buffersize(stream.buffer1) == 0
     state = stream.state
@@ -325,7 +325,14 @@ function Base.read(stream::TranscodingStream, ::Type{UInt8})
     if eof && sloweof(stream)
         throw(EOFError())
     end
-    return readbyte!(stream.buffer1)
+    buf = stream.buffer1
+    return buf.data[buf.bufferpos]
+end
+
+function Base.read(stream::TranscodingStream, ::Type{UInt8})::UInt8
+    x = peek(stream)
+    consumed!(stream.buffer1, 1)
+    x
 end
 
 function Base.readuntil(stream::TranscodingStream, delim::UInt8; keep::Bool=false)

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -314,6 +314,7 @@ end
 # Read Functions
 # --------------
 
+# needed for `peek(stream, Char)` to work
 function Base.peek(stream::TranscodingStream, ::Type{UInt8})::UInt8
     # eof and ready_to_read! are inlined here because ready_to_read! is very slow and eof is broken
     eof = buffersize(stream.buffer1) == 0

--- a/test/codecdoubleframe.jl
+++ b/test/codecdoubleframe.jl
@@ -386,6 +386,16 @@ DoubleFrameDecoderStream(stream::IO; kwargs...) = TranscodingStream(DoubleFrameD
         @test_throws ErrorException("short write") flush(stream)
     end
 
+    @testset "peek" begin
+        stream = DoubleFrameDecoderStream(DoubleFrameEncoderStream(IOBuffer(
+            codeunits("こんにちは")
+        )))
+        @test peek(stream) == 0xe3
+        @test peek(stream, Char) == 'こ'
+        @test peek(stream, Int32) == -476872221
+        close(stream)
+    end
+
     test_roundtrip_read(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
     test_roundtrip_write(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
     test_roundtrip_lines(DoubleFrameEncoderStream, DoubleFrameDecoderStream)

--- a/test/codecnoop.jl
+++ b/test/codecnoop.jl
@@ -541,4 +541,12 @@ using FillArrays: Zeros
         @test take!(sink) == b"abcd"
     end
 
+    @testset "peek" begin
+        stream = NoopStream(IOBuffer(codeunits("こんにちは")))
+        @test peek(stream) == 0xe3
+        @test peek(stream, Char) == 'こ'
+        @test peek(stream, Int32) == -476872221
+        close(stream)
+    end
+
 end


### PR DESCRIPTION
Fixes #224 by implementing `Base.peek(s::TranscodingStream, ::Type{UInt8})::UInt8`