### PR TITLE
Reset position in `seekstart`

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -286,8 +286,8 @@ function Base.seekstart(stream::TranscodingStream)
     mode = stream.state.mode
     if mode === :read
         callstartproc(stream, mode)
-        emptybuffer!(stream.buffer1)
-        emptybuffer!(stream.buffer2)
+        initbuffer!(stream.buffer1)
+        initbuffer!(stream.buffer2)
     elseif mode === :idle
     else
         throw_invalid_mode(mode)

--- a/test/codecquadruple.jl
+++ b/test/codecquadruple.jl
@@ -162,9 +162,9 @@ end
         @test read(stream, 5) == b"aaaab"
         @test position(stream) == 5
         @test seekstart(stream) == stream
-        @test_broken position(stream) == 0
+        @test position(stream) == 0
         @test read(stream, 5) == b"aaaab"
-        @test_broken position(stream) == 5
+        @test position(stream) == 5
     end
 
     @testset "seekstart doesn't delete data" begin


### PR DESCRIPTION
This resets position when calling `seekstart` to partially fix #109. `seekend` is still broken.