### PR TITLE
Add missing `ready_to_read!` to `unread`

### DIFF
--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -203,7 +203,7 @@ end
 
 # Insert data to the current buffer.
 # `data` must not alias `buf`
-function insertdata!(buf::Buffer, data::Union{AbstractArray{UInt8}, Memory})
+function insertdata!(buf::Buffer, data::Union{AbstractVector{UInt8}, Memory})
     nbytes = Int(length(data))
     makemargin!(buf, nbytes)
     datapos = if iszero(buf.markpos)

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -462,6 +462,7 @@ inserted.
 `data` must not alias any internal buffers in `stream`
 """
 function unread(stream::TranscodingStream, data::AbstractVector{UInt8})
+    ready_to_read!(stream)
     insertdata!(stream.buffer1, data)
     return nothing
 end

--- a/test/codecdoubleframe.jl
+++ b/test/codecdoubleframe.jl
@@ -396,6 +396,22 @@ DoubleFrameDecoderStream(stream::IO; kwargs...) = TranscodingStream(DoubleFrameD
         close(stream)
     end
 
+    @testset "unread" begin
+        stream = DoubleFrameDecoderStream(IOBuffer("[ ffoooobbaarr ]"))
+        @test position(stream) == 0
+        @test read(stream, 3) == b"foo"
+        @test position(stream) == 3
+        @test read(stream, 3) == b"bar"
+        @test position(stream) == 6
+        @test TranscodingStreams.unread(stream, b"baz") === nothing
+        @test position(stream) == 3
+        @test read(stream, 3) == b"baz"
+        @test position(stream) == 6
+        @test eof(stream)
+        @test position(stream) == 6
+        close(stream)
+    end
+
     test_roundtrip_read(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
     test_roundtrip_write(DoubleFrameEncoderStream, DoubleFrameDecoderStream)
     test_roundtrip_lines(DoubleFrameEncoderStream, DoubleFrameDecoderStream)


### PR DESCRIPTION
I forgot to add a call to `ready_to_read!` in #212.
This PR fixes that and adds tests that `unread` will error on a stream in write mode.
This PR also adds tests that `position` is correct after calling `unread`