### PR TITLE
BREAKING: remove generic `seekend` method

### DIFF
--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -118,13 +118,6 @@ function initbuffer!(buf::Buffer)
     return buf
 end
 
-# Remove all buffered data.
-function emptybuffer!(buf::Buffer)
-    buf.markpos = 0
-    buf.bufferpos = buf.marginpos = 1
-    return buf
-end
-
 # Make margin with ≥`minsize` and return the size of it.
 # If eager is true, it tries to move data even when the buffer has enough margin.
 function makemargin!(buf::Buffer, minsize::Int; eager::Bool = false)

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -296,20 +296,6 @@ function Base.seekstart(stream::TranscodingStream)
     return stream
 end
 
-function Base.seekend(stream::TranscodingStream)
-    mode = stream.state.mode
-    if mode == :read
-        callstartproc(stream, mode)
-        emptybuffer!(stream.buffer1)
-        emptybuffer!(stream.buffer2)
-    elseif mode === :idle
-    else
-        throw_invalid_mode(mode)
-    end
-    seekend(stream.stream)
-    return stream
-end
-
 
 # Read Functions
 # --------------

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ using TranscodingStreams:
     marginptr, marginsize, marginmem,
     readbyte!, writebyte!,
     #=ismarked,=# mark!, unmark!, reset!,
-    makemargin!, emptybuffer!
+    makemargin!, initbuffer!
 
 @testset "Buffer" begin
     buf = Buffer(1024)
@@ -68,7 +68,7 @@ using TranscodingStreams:
     writebyte!(buf, 0x99)
     margin_size = makemargin!(buf, 20) 
     @test margin_size >= 20
-    emptybuffer!(buf)
+    initbuffer!(buf)
     @test makemargin!(buf, 0) === margin_size + 2
 end
 


### PR DESCRIPTION
Fixes #109

See #183 for the reasoning for this change.

I am also removing `emptybuffer!` because it is now an unused internal method.