### PR TITLE
Bump version to 0.10.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "TranscodingStreams"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.10.9"
+version = "0.10.10"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
This release includes several bug fixes and the deprecation of the `Memory(::ByteData)` constructor (#219)
Diff: https://github.com/JuliaIO/TranscodingStreams.jl/compare/v0.10.9...0875466c1f99fa90614903cb2d24964ff38b8008