### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "TranscodingStreams"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.10.10"
+version = "0.11.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/TranscodingStreams.jl
+++ b/src/TranscodingStreams.jl
@@ -16,7 +16,6 @@ include("stream.jl")
 include("io.jl")
 include("noop.jl")
 include("transcode.jl")
-include("deprecated.jl")
 
 function test_roundtrip_read end
 function test_roundtrip_write end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,1 +1,0 @@
-Base.@deprecate Memory(data::ByteData) Memory(pointer(data), sizeof(data)) false


### PR DESCRIPTION
[How to migrate from v0.10 to v0.11](https://juliaio.github.io/TranscodingStreams.jl/dev/migrating/#Migration)
----------------------------------

v0.11 has a few subtle breaking changes to `eof` and `seekend`.

### `Memory(data::ByteData)`

The `Memory(data::ByteData)` constructor was removed.
Use `Memory(pointer(data), sizeof(data))` instead.

### `seekend(stream::TranscodingStream)`

Generic `seekend` for `TranscodingStream` was removed.
If the objective is to discard all remaining data in the stream, use `skip(stream, typemax(Int64))` instead where `typemax(Int64)` is meant to be a large number to exhaust the stream.
Ideally, specific implementations of `TranscodingStream` will implement `seekend` only if efficient means exist to avoid fully processing the stream.
`NoopStream` still supports `seekend`.

The previous behavior of the generic `seekend` was something like 
`(seekstart(stream); seekend(stream.stream); stream)` but this led to
inconsistencies with the position of the stream.

### `eof(stream::TranscodingStream)`

`eof` now throws an error if called on a stream that is closed or in writing mode.
Use `!isreadable(stream) || eof(stream)` if you need to more closely match previous behavior.