### PR TITLE
Fix `test_roundtrip_write`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "TranscodingStreams"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
This PR fixes `test_roundtrip_write` in the test extension. Before this fix `TOKEN_END` wasn't written to the underlying stream so some data might not get written out to the final `IOBuffer`.