### PR TITLE
Move TestExt back into the main package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,18 +4,5 @@ license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
 version = "0.11.1"
 
-[deps]
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[weakdeps]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-
-[extensions]
-TestExt = ["Test", "Random"]
-
 [compat]
-Random = "1"
-Test = "1"
 julia = "1.6"

--- a/src/TranscodingStreams.jl
+++ b/src/TranscodingStreams.jl
@@ -16,18 +16,6 @@ include("stream.jl")
 include("io.jl")
 include("noop.jl")
 include("transcode.jl")
-
-function test_roundtrip_read end
-function test_roundtrip_write end
-function test_roundtrip_transcode end
-function test_roundtrip_lines end
-function test_roundtrip_seekstart end
-function test_roundtrip_fileio end
-function test_chunked_read end
-function test_chunked_write end
-
-if !isdefined(Base, :get_extension)
-    include("../ext/TestExt.jl")
-end
+include("testtools.jl")
 
 end # module

--- a/src/testtools.jl
+++ b/src/testtools.jl
@@ -1,20 +1,12 @@
-module TestExt
+# Test Tools
+# ==========
 
-using Test: Test
-using Random: seed!, randstring
-
-using TranscodingStreams: TranscodingStreams, initialize, finalize, transcode, 
-    TranscodingStream, NoopStream, buffersize, TOKEN_END
-
-TEST_RANDOM_SEED = 12345
-
-function TranscodingStreams.test_roundtrip_read(encoder, decoder)
-    seed!(TEST_RANDOM_SEED)
+function test_roundtrip_read(encoder, decoder)
     for n in vcat(0:30, sort!(rand(500:100_000, 30))), alpha in (0x00:0xff, 0x00:0x0f)
         data = rand(alpha, n)
         file = IOBuffer(data)
         stream = decoder(encoder(file))
-        Test.@test hash(read(stream)) == hash(data)
+        read(stream) == data || error("test failed")
         close(stream)
     end
 end
@@ -25,73 +17,75 @@ function take_all(stream)
         seekstart(stream)
         read(stream)
     else
-        write(stream, TranscodingStreams.TOKEN_END)
+        write(stream, TOKEN_END)
         flush(stream)
         take_all(stream.stream)
     end
 end
 
-function TranscodingStreams.test_roundtrip_write(encoder, decoder)
-    seed!(TEST_RANDOM_SEED)
+function test_roundtrip_write(encoder, decoder)
     for n in vcat(0:30, sort!(rand(500:100_000, 30))), alpha in (0x00:0xff, 0x00:0x0f)
         data = rand(alpha, n)
-        stream = encoder(decoder(IOBuffer()))
+        sink = IOBuffer()
+        decode_sink = decoder(sink)
+        stream = encoder(decode_sink)
         write(stream, data)
-        Test.@test take_all(stream) == data
+        write(stream, TOKEN_END)
+        flush(stream)
+        write(decode_sink, TOKEN_END)
+        flush(decode_sink)
+        take!(sink) == data || error("test failed")
         close(stream)
     end
 end
 
-function TranscodingStreams.test_roundtrip_transcode(encode, decode)
-    seed!(TEST_RANDOM_SEED)
+function test_roundtrip_transcode(encode, decode)
     encoder = encode()
     initialize(encoder)
     decoder = decode()
     initialize(decoder)
     for n in vcat(0:30, sort!(rand(500:100_000, 30))), alpha in (0x00:0xff, 0x00:0x0f)
         data = rand(alpha, n)
-        Test.@test hash(transcode(decode, transcode(encode, data))) == hash(data)
-        Test.@test hash(transcode(decoder, transcode(encoder, data))) == hash(data)
+        transcode(decode, transcode(encode, data)) == data || error("test failed")
+        transcode(decoder, transcode(encoder, data)) == data || error("test failed")
     end
     finalize(encoder)
     finalize(decoder)
 end
 
-function TranscodingStreams.test_roundtrip_lines(encoder, decoder)
-    seed!(TEST_RANDOM_SEED)
+function test_roundtrip_lines(encoder, decoder)
     lines = String[]
     buf = IOBuffer()
     stream = encoder(buf)
     for i in 1:100_000
-        line = randstring(rand(0:1000))
+        line = String(rand(UInt8['A':'Z'; 'a':'z'; '0':'9';], rand(0:1000)))
         println(stream, line)
         push!(lines, line)
     end
     write(stream, TOKEN_END)
     flush(stream)
     seekstart(buf)
-    Test.@test hash(lines) == hash(readlines(decoder(buf)))
+    lines == readlines(decoder(buf)) || error("test failed")
 end
 
-function TranscodingStreams.test_roundtrip_seekstart(encoder, decoder)
-    seed!(TEST_RANDOM_SEED)
+function test_roundtrip_seekstart(encoder, decoder)
     for n in vcat(0:30, sort!(rand(500:100_000, 30))), alpha in (0x00:0xff, 0x00:0x0f)
         data = rand(alpha, n)
         file = IOBuffer(data)
         stream = decoder(encoder(file))
         for m in vcat(0:min(n,20), rand(0:n, 10))
-            Test.@test read(stream, m) == @view(data[1:m])
+            read(stream, m) == @view(data[1:m]) || error("test failed")
             seekstart(stream)
         end
         seekstart(stream)
-        Test.@test read(stream) == data
+        read(stream) == data || error("test failed")
         seekstart(stream)
-        Test.@test read(stream) == data
+        read(stream) == data || error("test failed")
         close(stream)
     end
 end
 
-function TranscodingStreams.test_roundtrip_fileio(Encoder, Decoder)
+function test_roundtrip_fileio(Encoder, Decoder)
     data = b"""
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sit amet tempus felis. Etiam molestie urna placerat iaculis pellentesque. Maecenas porttitor et dolor vitae posuere. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc eget nibh quam. Nullam aliquet interdum fringilla. Duis facilisis, lectus in consectetur varius, lorem sem tempor diam, nec auctor tellus nibh sit amet sapien. In ex nunc, elementum eget facilisis ut, luctus eu orci. Sed sapien urna, accumsan et elit non, auctor pretium massa. Phasellus consectetur nisi suscipit blandit aliquam. Nulla facilisi. Mauris pellentesque sem sit amet mi vestibulum eleifend. Nulla faucibus orci ac lorem efficitur, et blandit orci interdum. Aenean posuere ultrices ex sed rhoncus. Donec malesuada mollis sem, sed varius nunc sodales sed. Curabitur lobortis non justo non tristique.
     """
@@ -100,13 +94,12 @@ function TranscodingStreams.test_roundtrip_fileio(Encoder, Decoder)
         write(stream, data)
         close(stream)
         stream = TranscodingStream(Decoder(), open(filename))
-        Test.@test hash(read(stream)) == hash(data)
+        read(stream) == data || error("test failed")
         close(stream)
     end
 end
 
-function TranscodingStreams.test_chunked_read(Encoder, Decoder)
-    seed!(TEST_RANDOM_SEED)
+function test_chunked_read(Encoder, Decoder)
     alpha = b"色即是空"
     encoder = Encoder()
     initialize(encoder)
@@ -115,27 +108,24 @@ function TranscodingStreams.test_chunked_read(Encoder, Decoder)
             chunks = [rand(alpha, rand(0:100)) for _ in 1:rand(1:100)]
             data = mapfoldl(x->transcode(encoder, x), vcat, chunks, init=UInt8[])
             buffer = NoopStream(IOBuffer(data))
-            ok = true
             for chunk in chunks
                 stream = TranscodingStream(Decoder(), buffer; stop_on_end=true, sharedbuf)
-                ok &= read(stream) == chunk
-                ok &= position(stream) == length(chunk)
-                ok &= eof(stream)
-                ok &= isreadable(stream)
+                read(stream) == chunk || error("test failed")
+                position(stream) == length(chunk) || error("test failed")
+                eof(stream) || error("test failed")
+                isreadable(stream) || error("test failed")
                 close(stream)
             end
             # read without stop_on_end should read the full data.
             stream = TranscodingStream(Decoder(), IOBuffer(data))
-            ok &= read(stream) == reduce(vcat, chunks)
+            read(stream) == reduce(vcat, chunks) || error("test failed")
             close(stream)
-            Test.@test ok
         end
     end
     finalize(encoder)
 end
 
-function TranscodingStreams.test_chunked_write(Encoder, Decoder)
-    seed!(TEST_RANDOM_SEED)
+function test_chunked_write(Encoder, Decoder)
     alpha = b"空即是色"
     encoder = Encoder()
     initialize(encoder)
@@ -146,12 +136,7 @@ function TranscodingStreams.test_chunked_write(Encoder, Decoder)
         stream = TranscodingStream(Decoder(), buffer, stop_on_end=true)
         write(stream, vcat(data...))
         close(stream)
-        ok = true
-        ok &= hash(take!(buffer)) == hash(vcat(chunks...))
-        ok &= buffersize(stream.state.buffer1) == 0
-        Test.@test ok
+        take!(buffer) == vcat(chunks...) || error("test failed")
     end
     finalize(encoder)
 end
-
-end # module

--- a/src/testtools.jl
+++ b/src/testtools.jl
@@ -11,18 +11,6 @@ function test_roundtrip_read(encoder, decoder)
     end
 end
 
-# flush all nested streams and return final data
-function take_all(stream)
-    if stream isa Base.GenericIOBuffer
-        seekstart(stream)
-        read(stream)
-    else
-        write(stream, TOKEN_END)
-        flush(stream)
-        take_all(stream.stream)
-    end
-end
-
 function test_roundtrip_write(encoder, decoder)
     for n in vcat(0:30, sort!(rand(500:100_000, 30))), alpha in (0x00:0xff, 0x00:0x0f)
         data = rand(alpha, n)


### PR DESCRIPTION
This reverts #152 and is an alternative to #235 

The current strategy of using an extension for testing utilities is causing some issues: Ref #223 #234

This PR moves the functions defined in the extension back into the main package, with slight modifications to avoid depending on `Test` or `Random`. The functions aren't documented, so I don't think slightly changing their behavior is breaking.