### PR TITLE
Bump version to 0.11.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "TranscodingStreams"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.11.2"
+version = "0.11.3"
 
 [compat]
 julia = "1.6"


### PR DESCRIPTION
This release adds the optional `pledgeinsize` function to the transcoding protocol (PR #239)