### PR TITLE
Add test for reusing encoder after finalize

### DIFF
--- a/lib/TestsForCodecPackages/Project.toml
+++ b/lib/TestsForCodecPackages/Project.toml
@@ -1,7 +1,7 @@
 name = "TestsForCodecPackages"
 uuid = "c2e61002-3542-480d-8b3c-5f05cc4f8554"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,3 +6,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestsForCodecPackages = "c2e61002-3542-480d-8b3c-5f05cc4f8554"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+
+[sources]
+TranscodingStreams = {path = ".."}
+TestsForCodecPackages = {path = "../lib/TestsForCodecPackages"}

--- a/test/codecdoubleframe.jl
+++ b/test/codecdoubleframe.jl
@@ -13,7 +13,8 @@ using TestsForCodecPackages:
     test_roundtrip_seekstart,
     test_roundtrip_fileio,
     test_chunked_read,
-    test_chunked_write
+    test_chunked_write,
+    test_reuse_encoder
 
 # An insane codec for testing the codec APIs.
 struct DoubleFrameEncoder <: TranscodingStreams.Codec 
@@ -461,4 +462,5 @@ DoubleFrameDecoderStream(stream::IO; kwargs...) = TranscodingStream(DoubleFrameD
     test_roundtrip_fileio(DoubleFrameEncoder, DoubleFrameDecoder)
     test_chunked_read(DoubleFrameEncoder, DoubleFrameDecoder)
     test_chunked_write(DoubleFrameEncoder, DoubleFrameDecoder)
+    test_reuse_encoder(DoubleFrameEncoder, DoubleFrameDecoder)
 end


### PR DESCRIPTION
Fixes #241 

This PR adds a function `test_reuse_encoder(Encoder, Decoder)` to `TestsForCodecPackages.jl` and bumps the version from
0.1.0 to 0.1.1.

This test is from https://github.com/JuliaIO/CodecZstd.jl/pull/74